### PR TITLE
[FE/refactor] 프론트엔드 UI 통일 및 다크모드 지원 추가

### DIFF
--- a/frontend/src/app/admin/dashboard/page.tsx
+++ b/frontend/src/app/admin/dashboard/page.tsx
@@ -2,20 +2,30 @@
 
 import AdminProtectedRoute from '@/components/auth/AdminProtectedRoute';
 import AdminHeader from '@/components/layout/AdminHeader';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/Card';
 
 export default function AdminDashboardPage() {
   return (
     <AdminProtectedRoute>
-      <div className="min-h-screen bg-gray-100">
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
         <AdminHeader />
 
-        <main className="max-w-7xl mx-auto px-4 py-8">
-          <div className="bg-white rounded-lg shadow p-6">
-            <h2 className="text-xl font-semibold mb-4">환영합니다!</h2>
-            <p className="text-gray-600">
-              관리자 대시보드에 성공적으로 로그인했습니다.
-            </p>
-          </div>
+        <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+          <header className="mb-8">
+            <h1 className="text-3xl font-bold text-gray-900 dark:text-white">대시보드</h1>
+            <p className="text-gray-600 dark:text-gray-400 mt-1">관리자 대시보드에 오신 것을 환영합니다.</p>
+          </header>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>환영합니다!</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-gray-600 dark:text-gray-400">
+                관리자 대시보드에 성공적으로 로그인했습니다.
+              </p>
+            </CardContent>
+          </Card>
         </main>
       </div>
     </AdminProtectedRoute>

--- a/frontend/src/app/admin/login/page.tsx
+++ b/frontend/src/app/admin/login/page.tsx
@@ -2,7 +2,7 @@ import AdminLoginForm from '@/components/admin/AdminLoginForm';
 
 export default function AdminLoginPage() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 p-4">
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 p-4">
       <AdminLoginForm />
     </div>
   );

--- a/frontend/src/app/admin/reports/page.tsx
+++ b/frontend/src/app/admin/reports/page.tsx
@@ -7,14 +7,14 @@ import AdminHeader from '@/components/layout/AdminHeader';
 
 export default function AdminReportsPage() {
   return (
-      <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
-        <AdminHeader />
-            <AdminProtectedRoute>
-        <main className="p-4 sm:p-6 lg:p-8">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      <AdminHeader />
+      <AdminProtectedRoute>
+        <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
           <div className="max-w-6xl mx-auto">
             <header className="mb-8">
               <h1 className="text-3xl font-bold text-gray-900 dark:text-white">신고 관리</h1>
-              <p className="text-gray-600 dark:text-gray-300 mt-1">사용자 신고 내역을 확인하고 처리합니다.</p>
+              <p className="text-gray-600 dark:text-gray-400 mt-1">사용자 신고 내역을 확인하고 처리합니다.</p>
             </header>
 
             <Card>
@@ -30,7 +30,7 @@ export default function AdminReportsPage() {
             </Card>
           </div>
         </main>
-        </AdminProtectedRoute>
-      </div>
+      </AdminProtectedRoute>
+    </div>
   );
 }

--- a/frontend/src/app/admin/signup/page.tsx
+++ b/frontend/src/app/admin/signup/page.tsx
@@ -2,7 +2,7 @@ import AdminSignupForm from '@/components/admin/AdminSignupForm';
 
 export default function AdminSignupPage() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 p-4">
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 p-4">
       <AdminSignupForm />
     </div>
   );

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -287,40 +287,40 @@ export default function ChatListPage() {
 
   return (
     <ProtectedRoute>
-      <div className="min-h-screen bg-[#F9FAFB]">
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
         <AppHeader />
 
         {/* Main Content */}
         <div className="px-4 py-6">
           {/* Title */}
           <div className="mb-2">
-            <h1 className="text-2xl font-bold text-[#111827]">채팅</h1>
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-white">채팅</h1>
           </div>
           
           {/* Description */}
           <div className="mb-6">
-            <p className="text-[#6B7280] text-sm">매칭된 룸메이트와 대화를 나눠보세요</p>
+            <p className="text-gray-600 dark:text-gray-400 text-sm">매칭된 룸메이트와 대화를 나눠보세요</p>
           </div>
 
           {/* Loading */}
           {isLoading ? (
-            <div className="bg-white rounded-xl p-12 text-center">
-              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-[#4F46E5] mx-auto"></div>
-              <p className="mt-4 text-[#6B7280]">채팅방 목록을 불러오는 중...</p>
+            <div className="bg-white dark:bg-gray-800 rounded-xl p-12 text-center">
+              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 dark:border-blue-400 mx-auto"></div>
+              <p className="mt-4 text-gray-600 dark:text-gray-400">채팅방 목록을 불러오는 중...</p>
             </div>
           ) : chats.length === 0 ? (
-            <div className="bg-white rounded-xl p-12 text-center">
-              <div className="w-16 h-16 bg-[#F3F4F6] rounded-full flex items-center justify-center mx-auto mb-4">
-                <User className="w-8 h-8 text-[#9CA3AF]" />
+            <div className="bg-white dark:bg-gray-800 rounded-xl p-12 text-center">
+              <div className="w-16 h-16 bg-gray-100 dark:bg-gray-700 rounded-full flex items-center justify-center mx-auto mb-4">
+                <User className="w-8 h-8 text-gray-400 dark:text-gray-500" />
               </div>
-              <h3 className="text-lg font-semibold text-[#111827] mb-2">아직 매칭된 대화가 없습니다</h3>
-              <p className="text-[#6B7280] mb-6">
+              <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">아직 매칭된 대화가 없습니다</h3>
+              <p className="text-gray-600 dark:text-gray-400 mb-6">
                 매칭 페이지에서 마음에 드는 프로필에 좋아요를 눌러보세요.<br />
                 상대방도 좋아요를 누르면 채팅방이 생성됩니다!
               </p>
               <button 
                 onClick={() => router.push('/matches')}
-                className="text-[#4F46E5] font-medium hover:underline"
+                className="text-blue-600 dark:text-blue-400 font-medium hover:underline"
               >
                 매칭 페이지로 가기 →
               </button>
@@ -331,7 +331,7 @@ export default function ChatListPage() {
                 {chats.map((chat) => (
                 <div
                   key={chat.chatroomId}
-                  className="bg-white rounded-xl p-6 shadow-md hover:shadow-lg transition-shadow cursor-pointer relative border border-gray-100"
+                  className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md hover:shadow-lg transition-shadow cursor-pointer relative border border-gray-100 dark:border-gray-700"
                   onClick={() => {
                     // 메뉴가 열려있으면 채팅방으로 이동하지 않음
                     if (showMenu !== chat.chatroomId) {
@@ -344,15 +344,15 @@ export default function ChatListPage() {
                     <div className="flex-1 min-w-0">
                       <div className="flex items-start justify-between mb-2">
                         <div className="flex items-center gap-2">
-                          <h3 className="font-semibold text-[#111827]">{chat.partnerName || `사용자 ${chat.partnerId || chat.user1Id || chat.user2Id}`}</h3>
+                          <h3 className="font-semibold text-gray-900 dark:text-white">{chat.partnerName || `사용자 ${chat.partnerId || chat.user1Id || chat.user2Id}`}</h3>
                           {chat.isNew && (
-                            <span className="bg-[#EF4444] text-white text-xs px-2 py-1 rounded font-semibold">
+                            <span className="bg-red-500 dark:bg-red-600 text-white text-xs px-2 py-1 rounded font-semibold">
                               NEW
                             </span>
                           )}
                         </div>
                         <div className="flex items-center gap-2">
-                          <span className="text-sm text-[#9CA3AF]">
+                          <span className="text-sm text-gray-500 dark:text-gray-400">
                             {chat.lastMessageTime 
                               ? new Date(chat.lastMessageTime).toLocaleTimeString('ko-KR', { 
                                   hour: '2-digit', 
@@ -362,13 +362,13 @@ export default function ChatListPage() {
                             }
                           </span>
                           {chat.unreadCount && chat.unreadCount > 0 ? (
-                            <span className="bg-[#4F46E5] text-white text-xs px-2 py-1 rounded-full min-w-[20px] text-center font-semibold">
+                            <span className="bg-blue-600 dark:bg-blue-500 text-white text-xs px-2 py-1 rounded-full min-w-[20px] text-center font-semibold">
                               {chat.unreadCount > 99 ? '99+' : chat.unreadCount}
                             </span>
                           ) : null}
                         </div>
                       </div>
-                      <p className="text-[#6B7280] truncate">
+                      <p className="text-gray-600 dark:text-gray-400 truncate">
                         {chat.lastMessage || '매칭되었습니다! 안녕하세요 👋'}
                       </p>
                     </div>
@@ -380,9 +380,9 @@ export default function ChatListPage() {
                           e.stopPropagation()
                           setShowMenu(showMenu === chat.chatroomId ? null : chat.chatroomId)
                         }}
-                        className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-[#F3F4F6] transition-colors"
+                        className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
                       >
-                        <MoreVertical className="w-5 h-5 text-[#6B7280]" />
+                        <MoreVertical className="w-5 h-5 text-gray-600 dark:text-gray-400" />
                       </button>
 
                       {/* Dropdown Menu */}
@@ -392,44 +392,44 @@ export default function ChatListPage() {
                             className="fixed inset-0 z-10" 
                             onClick={() => setShowMenu(null)}
                           />
-                          <div className="absolute right-0 top-10 w-48 bg-white border border-[#E5E7EB] rounded-xl shadow-lg z-20 overflow-hidden">
+                          <div className="absolute right-0 top-10 w-48 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl shadow-lg z-20 overflow-hidden">
                             <button
                               onClick={(e) => {
                                 e.stopPropagation()
                                 setShowReportModal({ chatId: chat.chatroomId, partnerName: chat.partnerName || '알 수 없는 사용자' })
                                 setShowMenu(null)
                               }}
-                              className="w-full px-4 py-3 flex items-center gap-3 text-left hover:bg-[#FEF3C7] transition-colors"
+                              className="w-full px-4 py-3 flex items-center gap-3 text-left hover:bg-yellow-50 dark:hover:bg-yellow-900/20 transition-colors"
                             >
-                              <Flag className="w-4 h-4 text-[#F59E0B]" />
-                              <span className="text-sm text-[#F59E0B]">신고하기</span>
+                              <Flag className="w-4 h-4 text-yellow-600 dark:text-yellow-400" />
+                              <span className="text-sm text-yellow-600 dark:text-yellow-400">신고하기</span>
                             </button>
                             <button
                               onClick={(e) => {
                                 e.stopPropagation()
                                 const currentUserId = typeof window !== 'undefined' ? 
                                   parseInt(localStorage.getItem('userId') || '0') : 0
-                                const partnerId = chat.user1Id === currentUserId ? chat.user2Id : chat.user1Id || chat.partnerId || 0
+                                const partnerId = (chat.user1Id === currentUserId ? chat.user2Id : chat.user1Id) || chat.partnerId || 0
                                 
                                 setShowBlockModal({ 
                                   chatId: chat.chatroomId, 
-                                  partnerId: partnerId,
+                                  partnerId: partnerId, 
                                   partnerName: chat.partnerName || '알 수 없는 사용자',
                                   isBlocked: chat.isBlocked || false
                                 })
                                 setShowMenu(null)
                               }}
-                              className="w-full px-4 py-3 flex items-center gap-3 text-left hover:bg-[#FEE2E2] transition-colors"
+                              className="w-full px-4 py-3 flex items-center gap-3 text-left hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
                             >
                               {chat.isBlocked ? (
                                 <>
-                                  <Unlock className="w-4 h-4 text-[#10B981]" />
-                                  <span className="text-sm text-[#10B981]">차단 해제</span>
+                                  <Unlock className="w-4 h-4 text-green-600 dark:text-green-400" />
+                                  <span className="text-sm text-green-600 dark:text-green-400">차단 해제</span>
                                 </>
                               ) : (
                                 <>
-                                  <Ban className="w-4 h-4 text-[#EF4444]" />
-                                  <span className="text-sm text-[#EF4444]">차단하기</span>
+                                  <Ban className="w-4 h-4 text-red-600 dark:text-red-400" />
+                                  <span className="text-sm text-red-600 dark:text-red-400">차단하기</span>
                                 </>
                               )}
                             </button>
@@ -439,10 +439,10 @@ export default function ChatListPage() {
                                 setShowDeleteModal(chat.chatroomId)
                                 setShowMenu(null)
                               }}
-                              className="w-full px-4 py-3 flex items-center gap-3 text-left hover:bg-[#FEE2E2] transition-colors"
+                              className="w-full px-4 py-3 flex items-center gap-3 text-left hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
                             >
-                              <Trash2 className="w-4 h-4 text-[#EF4444]" />
-                              <span className="text-sm text-[#EF4444]">채팅방 나가기</span>
+                              <Trash2 className="w-4 h-4 text-red-600 dark:text-red-400" />
+                              <span className="text-sm text-red-600 dark:text-red-400">채팅방 나가기</span>
                             </button>
                           </div>
                         </>
@@ -458,19 +458,19 @@ export default function ChatListPage() {
           {/* Delete Chat Modal */}
           {showDeleteModal !== null && (
             <div className="fixed inset-0 bg-transparent flex items-center justify-center z-50">
-              <div className="bg-white rounded-xl p-6 w-full max-w-md mx-4">
+              <div className="bg-white dark:bg-gray-800 rounded-xl p-6 w-full max-w-md mx-4">
                 <div className="flex items-center gap-3 mb-4">
-                  <div className="w-12 h-12 bg-[#FEE2E2] rounded-xl flex items-center justify-center">
-                    <Trash2 className="w-6 h-6 text-[#EF4444]" />
+                  <div className="w-12 h-12 bg-red-100 dark:bg-red-900/20 rounded-xl flex items-center justify-center">
+                    <Trash2 className="w-6 h-6 text-red-600 dark:text-red-400" />
                   </div>
                   <div>
-                    <h3 className="text-lg font-semibold text-[#111827]">채팅방 나가기</h3>
-                    <p className="text-sm text-[#6B7280]">이 채팅방에서 나가시겠습니까?</p>
+                    <h3 className="text-lg font-semibold text-gray-900 dark:text-white">채팅방 나가기</h3>
+                    <p className="text-sm text-gray-600 dark:text-gray-400">이 채팅방에서 나가시겠습니까?</p>
                   </div>
                 </div>
 
-                <div className="p-4 bg-[#FEF2F2] border border-[#FEE2E2] rounded-xl mb-4">
-                  <p className="text-sm text-[#991B1B]">
+                <div className="p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-xl mb-4">
+                  <p className="text-sm text-red-800 dark:text-red-300">
                     나간 채팅방은 다시 들어갈 수 없습니다.
                   </p>
                 </div>
@@ -478,13 +478,13 @@ export default function ChatListPage() {
                 <div className="flex gap-3">
                   <button
                     onClick={() => setShowDeleteModal(null)}
-                    className="flex-1 px-4 py-3 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors"
+                    className="flex-1 px-4 py-3 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
                   >
                     취소
                   </button>
                   <button
                     onClick={() => handleDeleteChat(showDeleteModal)}
-                    className="flex-1 px-4 py-3 bg-[#EF4444] text-white rounded-lg hover:bg-[#DC2626] transition-colors"
+                    className="flex-1 px-4 py-3 bg-red-600 dark:bg-red-500 text-white rounded-lg hover:bg-red-700 dark:hover:bg-red-600 transition-colors"
                   >
                     삭제하기
                   </button>
@@ -507,22 +507,22 @@ export default function ChatListPage() {
           {/* Block Modal */}
           {showBlockModal && (
             <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-              <div className="bg-white rounded-xl p-6 w-full max-w-md mx-4">
+              <div className="bg-white dark:bg-gray-800 rounded-xl p-6 w-full max-w-md mx-4">
                 <div className="flex items-center gap-3 mb-4">
                   <div className={`w-12 h-12 rounded-xl flex items-center justify-center ${
-                    showBlockModal.isBlocked ? 'bg-[#D1FAE5]' : 'bg-[#FEE2E2]'
+                    showBlockModal.isBlocked ? 'bg-green-100 dark:bg-green-900/20' : 'bg-red-100 dark:bg-red-900/20'
                   }`}>
                     {showBlockModal.isBlocked ? (
-                      <Unlock className="w-6 h-6 text-[#10B981]" />
+                      <Unlock className="w-6 h-6 text-green-600 dark:text-green-400" />
                     ) : (
-                      <Ban className="w-6 h-6 text-[#EF4444]" />
+                      <Ban className="w-6 h-6 text-red-600 dark:text-red-400" />
                     )}
                   </div>
                   <div>
-                    <h3 className="text-lg font-semibold text-[#111827]">
+                    <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
                       {showBlockModal.isBlocked ? '차단 해제' : '사용자 차단'}
                     </h3>
-                    <p className="text-sm text-[#6B7280]">
+                    <p className="text-sm text-gray-600 dark:text-gray-400">
                       {showBlockModal.partnerName}님을 {showBlockModal.isBlocked ? '차단 해제' : '차단'}하시겠습니까?
                     </p>
                   </div>
@@ -530,15 +530,15 @@ export default function ChatListPage() {
 
                 <div className={`p-4 rounded-xl mb-4 ${
                   showBlockModal.isBlocked 
-                    ? 'bg-[#ECFDF5] border border-[#D1FAE5]' 
-                    : 'bg-[#FEF2F2] border border-[#FEE2E2]'
+                    ? 'bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800' 
+                    : 'bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800'
                 }`}>
                   {showBlockModal.isBlocked ? (
-                    <p className="text-sm text-[#065F46]">
+                    <p className="text-sm text-green-800 dark:text-green-300">
                       차단을 해제하면 이 사용자의 메시지를 다시 받을 수 있습니다.
                     </p>
                   ) : (
-                    <p className="text-sm text-[#991B1B]">
+                    <p className="text-sm text-red-800 dark:text-red-300">
                       차단하면 이 사용자의 메시지를 더 이상 받지 않습니다.<br />
                       차단된 기간 동안의 메시지는 전달되지 않으며, 차단 해제 후에도 과거 메시지는 받을 수 없습니다.
                     </p>
@@ -549,7 +549,7 @@ export default function ChatListPage() {
                   <button
                     onClick={() => setShowBlockModal(null)}
                     disabled={isBlocking}
-                    className="flex-1 px-4 py-3 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors disabled:opacity-50"
+                    className="flex-1 px-4 py-3 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors disabled:opacity-50"
                   >
                     취소
                   </button>
@@ -558,8 +558,8 @@ export default function ChatListPage() {
                     disabled={isBlocking}
                     className={`flex-1 px-4 py-3 text-white rounded-lg transition-colors disabled:opacity-50 ${
                       showBlockModal.isBlocked
-                        ? 'bg-[#10B981] hover:bg-[#059669]'
-                        : 'bg-[#EF4444] hover:bg-[#DC2626]'
+                        ? 'bg-green-600 dark:bg-green-500 hover:bg-green-700 dark:hover:bg-green-600'
+                        : 'bg-red-600 dark:bg-red-500 hover:bg-red-700 dark:hover:bg-red-600'
                     }`}
                   >
                     {isBlocking ? '처리 중...' : showBlockModal.isBlocked ? '차단 해제' : '차단하기'}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -222,3 +222,37 @@ body {
   transform: translateY(-1px);
   box-shadow: var(--shadow-md);
 }
+
+/* 통일된 색상 유틸리티 클래스 */
+.bg-page {
+  background-color: var(--muted);
+}
+
+.dark .bg-page {
+  background-color: var(--background);
+}
+
+.text-primary {
+  color: var(--primary);
+}
+
+.text-foreground {
+  color: var(--foreground);
+}
+
+.text-muted {
+  color: var(--muted-foreground);
+}
+
+.border-default {
+  border-color: var(--border);
+}
+
+/* 통일된 그라데이션 */
+.gradient-primary {
+  background: linear-gradient(135deg, var(--primary) 0%, var(--primary-light) 100%);
+}
+
+.gradient-brand {
+  background: linear-gradient(135deg, #4F46E5 0%, #6366F1 100%);
+}

--- a/frontend/src/app/matches/page.tsx
+++ b/frontend/src/app/matches/page.tsx
@@ -288,7 +288,7 @@ export default function MatchesPage() {
                         <h3 className="text-lg font-bold text-gray-900 dark:text-white">필터</h3>
                         <button
                           onClick={handleResetFilters}
-                          className="text-sm text-[#6366F1] hover:text-[#4F46E5] font-medium"
+                          className="text-sm text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 font-medium"
                         >
                           초기화
                         </button>

--- a/frontend/src/app/matches/results/page.tsx
+++ b/frontend/src/app/matches/results/page.tsx
@@ -9,6 +9,7 @@ import { MatchService } from '../../../lib/services/matchService';
 import { getErrorMessage } from '../../../lib/utils/helpers';
 import type { MatchResultResponse, MatchResultItem } from '../../../types/match';
 import { User, Calendar, Home, Phone } from 'lucide-react';
+import AppHeader from '@/components/layout/AppHeader';
 
 interface EnrichedMatchResult extends MatchResultItem {
   partnerDetails?: any; // 상세 정보
@@ -80,6 +81,7 @@ export default function MatchResultsPage() {
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      <AppHeader />
       <div className="max-w-7xl mx-auto px-4 py-8">
         {/* 헤더 */}
         <div className="mb-8 flex items-center justify-between">
@@ -267,8 +269,8 @@ export default function MatchResultsPage() {
           <div className="fixed top-4 right-4 z-50">
             <div className={`max-w-sm w-full border rounded-lg shadow-lg p-4 ${
               toast.type === 'success' 
-                ? 'bg-green-50 border-green-200 text-green-800' 
-                : 'bg-red-50 border-red-200 text-red-800'
+                ? 'bg-green-50 dark:bg-green-900/20 border-green-200 dark:border-green-800 text-green-800 dark:text-green-300' 
+                : 'bg-red-50 dark:bg-red-900/20 border-red-200 dark:border-red-800 text-red-800 dark:text-red-300'
             }`}>
               <div className="flex items-start">
                 <div className="flex-shrink-0 mr-3">

--- a/frontend/src/app/matches/status/page.tsx
+++ b/frontend/src/app/matches/status/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { MatchStatusCard } from '../../../components/matches/MatchStatusCard';
 import { Card } from '../../../components/ui/Card';
@@ -9,12 +9,15 @@ import LoadingSpinner from '../../../components/ui/LoadingSpinner';
 import { MatchService } from '../../../lib/services/matchService';
 import { getErrorMessage } from '../../../lib/utils/helpers';
 import type { MatchStatusResponse } from '../../../types/match';
+import { CheckCircle, XCircle, MessageCircle } from 'lucide-react';
+import AppHeader from '@/components/layout/AppHeader'; 
 
 export default function MatchStatusPage() {
   const router = useRouter();
   const [matchStatus, setMatchStatus] = useState<MatchStatusResponse | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
+  const [processingMatchId, setProcessingMatchId] = useState<number | null>(null);  
 
   // 토스트 자동 제거
   useEffect(() => {
@@ -25,7 +28,7 @@ export default function MatchStatusPage() {
   }, [toast]);
 
   // 매칭 상태 조회
-  const fetchMatchStatus = async () => {
+  const fetchMatchStatus = useCallback(async () => {
     try {
       setIsLoading(true);
       const response = await MatchService.getMatchStatus();
@@ -37,6 +40,56 @@ export default function MatchStatusPage() {
     } finally {
       setIsLoading(false);
     }
+  }, []);
+
+  const handleConfirmMatch = async (matchId: number) => {
+    if (!confirm('룸메이트 매칭을 확정하시겠습니까?')) {
+      return;
+    }
+
+    try {
+      setProcessingMatchId(matchId);
+      await MatchService.confirmMatch(matchId);
+      setToast({ message: '✅ 매칭이 확정되었습니다!', type: 'success' });
+      await fetchMatchStatus(); // 상태 새로고침
+    } catch (error) {
+      console.error('매칭 확정 실패:', error);
+      const errorMessage = getErrorMessage(error);
+      if (errorMessage.includes('이미 응답')) {
+        setToast({ message: '⚠️ 이미 확정 의사를 전달했습니다.', type: 'error' });
+      } else {
+        setToast({ message: errorMessage, type: 'error' });
+      }
+    } finally {
+      setProcessingMatchId(null);
+    }
+  };
+
+  const handleRejectMatch = async (matchId: number, partnerName: string) => {
+    if (!confirm(`${partnerName}님과의 룸메이트 매칭을 거절하시겠습니까?\n거절 시 다시 되돌릴 수 없습니다.`)) {
+      return;
+    }
+
+    try {
+      setProcessingMatchId(matchId);
+      await MatchService.rejectMatch(matchId);
+      setToast({ message: '❌ 매칭을 거절했습니다.', type: 'success' });
+      await fetchMatchStatus(); // 상태 새로고침
+    } catch (error) {
+      console.error('매칭 거절 실패:', error);
+      const errorMessage = getErrorMessage(error);
+      if (errorMessage.includes('이미 응답')) {
+        setToast({ message: '⚠️ 이미 거절 의사를 전달했습니다.', type: 'error' });
+      } else {
+        setToast({ message: errorMessage, type: 'error' });
+      }
+    } finally {
+      setProcessingMatchId(null);
+    }
+  };
+
+  const handleGoToChat = () => {
+    router.push('/chat');
   };
 
   // 새로고침
@@ -56,7 +109,7 @@ export default function MatchStatusPage() {
 
   useEffect(() => {
     fetchMatchStatus();
-  }, []);
+  }, [fetchMatchStatus]);
 
   if (isLoading) {
     return (
@@ -88,6 +141,7 @@ export default function MatchStatusPage() {
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      <AppHeader />  {/* ✅ 추가 */}
       <div className="max-w-7xl mx-auto px-4 py-8">
         {/* 헤더 */}
         <div className="flex justify-between items-center mb-8">
@@ -114,55 +168,179 @@ export default function MatchStatusPage() {
         </div>
 
         {/* 매칭 목록 */}
-        {matchStatus.matches && matchStatus.matches.length > 0 && (
+        {matchStatus.matches && matchStatus.matches.length > 0 ? (
           <div className="space-y-4 mb-8">
             <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
               매칭 목록
             </h2>
-            {matchStatus.matches.map((match) => (
-              <Card key={match.id} className="p-6">
-                <div className="flex items-center justify-between mb-4">
-                  <div>
-                    <h3 className="text-lg font-medium text-gray-900 dark:text-white">
-                      {match.partner.name}
-                    </h3>
-                    <p className="text-sm text-gray-500 dark:text-gray-400">
-                      {match.partner.university}
-                    </p>
-                  </div>
-                  <span className={`px-3 py-1 rounded-full text-sm font-medium ${
-                    match.matchStatus === 'PENDING' ? 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400' :
-                    match.matchStatus === 'ACCEPTED' ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400' :
-                    'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400'
-                  }`}>
-                    {match.matchStatus === 'PENDING' && '대기 중'}
-                    {match.matchStatus === 'ACCEPTED' && '수락됨'}
-                    {match.matchStatus === 'REJECTED' && '거절됨'}
-                  </span>
-                </div>
-                <div className="space-y-2">
-                  <div className="text-sm text-gray-600 dark:text-gray-400">
-                    {match.matchType === 'LIKE' ? '💝 좋아요' : '✨ 정식 룸메 신청'}
-                  </div>
-                  {match.message && (
-                    <p className="text-sm text-gray-500 dark:text-gray-400 italic">
-                      {match.message}
-                    </p>
-                  )}
-                  <div className="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
-                    <span>매칭률: {Math.round((match.preferenceScore || 0) * 100)}%</span>
-                    <span>•</span>
-                    <span>
-                      {new Date(match.createdAt).toLocaleDateString('ko-KR', {
-                        year: 'numeric',
-                        month: 'long',
-                        day: 'numeric'
-                      })}
+            {matchStatus.matches.map((match) => {
+              const myResponse = match.myResponse;
+              const partnerResponse = match.partnerResponse;
+              const isWaitingForPartner = match.waitingForPartner;
+              const canRespond = match.matchStatus === 'PENDING' && myResponse === 'PENDING';
+              const isProcessing = processingMatchId === match.id;
+
+              return (
+                <Card key={match.id} className="p-6 hover:shadow-lg transition-shadow">
+                  <div className="flex items-center justify-between mb-4">
+                    <div>
+                      <h3 className="text-lg font-medium text-gray-900 dark:text-white">
+                        {match.partner.name}
+                      </h3>
+                      <p className="text-sm text-gray-500 dark:text-gray-400">
+                        {match.partner.university}
+                      </p>
+                    </div>
+                    <span className={`px-3 py-1 rounded-full text-sm font-medium ${
+                      match.matchStatus === 'PENDING' ? 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400' :
+                      match.matchStatus === 'ACCEPTED' ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400' :
+                      'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400'
+                    }`}>
+                      {match.matchStatus === 'PENDING' && '대기 중'}
+                      {match.matchStatus === 'ACCEPTED' && '수락됨'}
+                      {match.matchStatus === 'REJECTED' && '거절됨'}
                     </span>
                   </div>
-                </div>
-              </Card>
-            ))}
+
+                  {/* 양방향 응답 상태 표시 */}
+                  <div className="mb-4 space-y-2">
+                    <div className="flex items-center gap-4 text-sm">
+                      <div className="flex items-center gap-2">
+                        <span className="text-gray-600 dark:text-gray-400">내 응답:</span>
+                        <span className={`px-2 py-1 rounded text-xs font-medium ${
+                          myResponse === 'ACCEPTED' ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400' :
+                          myResponse === 'REJECTED' ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400' :
+                          'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300'
+                        }`}>
+                          {myResponse === 'PENDING' && '대기 중'}
+                          {myResponse === 'ACCEPTED' && '수락함'}
+                          {myResponse === 'REJECTED' && '거절함'}
+                        </span>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <span className="text-gray-600 dark:text-gray-400">상대방 응답:</span>
+                        <span className={`px-2 py-1 rounded text-xs font-medium ${
+                          partnerResponse === 'ACCEPTED' ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400' :
+                          partnerResponse === 'REJECTED' ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400' :
+                          'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300'
+                        }`}>
+                          {partnerResponse === 'PENDING' && '대기 중'}
+                          {partnerResponse === 'ACCEPTED' && '수락함'}
+                          {partnerResponse === 'REJECTED' && '거절함'}
+                        </span>
+                      </div>
+                    </div>
+
+                    {/* 상대방 응답 대기 중 표시 */}
+                    {isWaitingForPartner && (
+                      <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-3">
+                        <p className="text-sm text-blue-700 dark:text-blue-300 font-medium">
+                          ⏰ 상대방의 응답을 기다리고 있습니다
+                        </p>
+                      </div>
+                    )}
+
+                    {/* 상대방이 수락한 경우 안내 */}
+                    {partnerResponse === 'ACCEPTED' && myResponse === 'PENDING' && (
+                      <div className="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg p-3">
+                        <p className="text-sm text-green-700 dark:text-green-300 font-medium">
+                          ✅ 상대방이 수락했습니다. 아래에서 확정하거나 거절할 수 있습니다.
+                        </p>
+                      </div>
+                    )}
+
+                    {/* 상대방이 거절한 경우 안내 */}
+                    {partnerResponse === 'REJECTED' && (
+                      <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-3">
+                        <p className="text-sm text-red-700 dark:text-red-300 font-medium">
+                          ❌ 상대방이 거절했습니다
+                        </p>
+                      </div>
+                    )}
+                  </div>
+
+                  <div className="space-y-2 mb-4">
+                    <div className="text-sm text-gray-600 dark:text-gray-400">
+                      {match.matchType === 'LIKE' ? '💝 좋아요' : '✨ 정식 룸메 신청'}
+                    </div>
+                    {match.message && (
+                      <p className="text-sm text-gray-500 dark:text-gray-400 italic">
+                        {match.message}
+                      </p>
+                    )}
+                    <div className="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+                      <span>매칭률: {Math.round((match.preferenceScore || 0) * 100)}%</span>
+                      <span>•</span>
+                      <span>
+                        {new Date(match.createdAt).toLocaleDateString('ko-KR', {
+                          year: 'numeric',
+                          month: 'long',
+                          day: 'numeric'
+                        })}
+                      </span>
+                    </div>
+                  </div>
+
+                  {/* 액션 버튼 영역 */}
+                  <div className="flex gap-2 pt-4 border-t border-gray-200 dark:border-gray-700">
+                    {canRespond && (
+                      <>
+                        <Button
+                          variant="outline"
+                          onClick={() => handleRejectMatch(match.id, match.partner.name)}
+                          disabled={isProcessing}
+                          className="flex-1 flex items-center justify-center"
+                        >
+                          <XCircle className="w-4 h-4 mr-2" />
+                          <span>{isProcessing ? '처리 중...' : '거절'}</span>
+                        </Button>
+                        <Button
+                          onClick={() => handleConfirmMatch(match.id)}
+                          disabled={isProcessing}
+                          className="flex-1 flex items-center justify-center"
+                        >
+                          <CheckCircle className="w-4 h-4 mr-2" />
+                          <span>{isProcessing ? '처리 중...' : '확정'}</span>
+                        </Button>
+                      </>
+                    )}
+                    {match.matchStatus === 'ACCEPTED' && (
+                      <Button
+                        onClick={handleGoToChat}
+                        className="flex-1 flex items-center justify-center"
+                      >
+                        <MessageCircle className="w-4 h-4 mr-2" />
+                        <span>채팅하기</span>
+                      </Button>
+                    )}
+                    {!canRespond && match.matchStatus === 'PENDING' && (
+                      <div className="flex-1 text-sm text-gray-500 dark:text-gray-400 text-center py-2">
+                        상대방의 응답을 기다리는 중입니다
+                      </div>
+                    )}
+                  </div>
+                </Card>
+              );
+            })}
+          </div>
+        ) : (
+          // 빈 매칭 목록 UI 추가
+          <div className="flex flex-col items-center justify-center py-20 mb-8">
+            <div className="w-32 h-32 bg-gradient-to-br from-blue-100 to-indigo-100 dark:from-blue-900/20 dark:to-indigo-900/20 rounded-full flex items-center justify-center mb-6">
+              <svg className="w-16 h-16 text-blue-400 dark:text-blue-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
+              </svg>
+            </div>
+            <h3 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">
+              아직 매칭이 없습니다
+            </h3>
+            <p className="text-gray-600 dark:text-gray-400 mb-8 text-center max-w-md">
+              추천 목록에서 마음에 드는 룸메이트를 찾아<br />
+              좋아요를 보내고 대화를 시작해보세요!
+            </p>
+            <Button onClick={handleViewRecommendations}>
+              룸메이트 찾으러 가기
+            </Button>
           </div>
         )}
 
@@ -189,7 +367,7 @@ export default function MatchStatusPage() {
                   <span className="text-lg">{toast.type === 'success' ? '✅' : '❌'}</span>
                 </div>
                 <div className="flex-1">
-                  <p className="text-sm">{toast.message}</p>
+                  <p className="text-sm whitespace-pre-line">{toast.message}</p> 
                 </div>
                 <button
                   onClick={() => setToast(null)}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -2,11 +2,11 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import Link from "next/link";
 import Button from '@/components/ui/Button';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/Card';
 import AppHeader from '@/components/layout/AppHeader';
 import { ProfileService } from '@/lib/services/profileService';
+import AuthService from '@/lib/services/authService';
 
 export default function Home() {
   const router = useRouter();
@@ -17,20 +17,40 @@ export default function Home() {
   useEffect(() => {
     const checkAuthAndProfile = async () => {
       try {
-        const token = localStorage.getItem('token');
-        if (token) {
+        // AuthService 사용하여 토큰 유효성 확인
+        if (AuthService.isAuthenticated()) {
           setIsLoggedIn(true);
           
           // 프로필 존재 여부 확인
           try {
-            await ProfileService.getProfile();
+            await ProfileService.getMyProfile();
             setHasProfile(true);
-          } catch {
-            setHasProfile(false);
+          } catch (error: any) {
+            // 에러 타입별 처리
+            const status = error?.response?.status || error?.status;
+            
+            if (status === 404) {
+              // 프로필이 없는 정상적인 케이스
+              setHasProfile(false);
+            } else if (status === 401) {
+              // 인증 실패 - 로그인 상태 해제
+              setIsLoggedIn(false);
+              setHasProfile(false);
+              AuthService.clearTokens();
+            } else {
+              // 기타 에러
+              console.error('프로필 조회 실패:', error);
+              setHasProfile(false);
+            }
           }
+        } else {
+          setIsLoggedIn(false);
+          setHasProfile(false);
         }
       } catch (error) {
         console.error('인증 확인 실패:', error);
+        setIsLoggedIn(false);
+        setHasProfile(false);
       } finally {
         setIsLoading(false);
       }
@@ -53,34 +73,41 @@ export default function Home() {
   const handleLoginClick = (e: React.MouseEvent) => {
     e.preventDefault();
     if (isLoggedIn) {
-      router.push('/profile');
+      // 프로필 유무에 따라 다른 경로로 이동
+      if (hasProfile) {
+        // 프로필이 있으면 매칭 페이지로 이동 
+        router.push('/matches');
+      } else {
+        // 프로필이 없으면 프로필 생성 페이지로 이동
+        router.push('/profile/create');
+      }
     } else {
       router.push('/login');
     }
   };
 
   return (
-    <div className="min-h-screen bg-[#F9FAFB]">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
       <AppHeader />
-      <div className="container mx-auto px-4 py-8 bg-white min-h-screen">
+      <div className="max-w-7xl mx-auto px-4 py-8">
         {/* 히어로 섹션 */}
         <section className="text-center py-20 relative overflow-hidden">
-          <div className="absolute inset-0 bg-gradient-to-br from-blue-50 via-white to-cyan-50 opacity-50"></div>
+          <div className="absolute inset-0 bg-gradient-to-br from-blue-100 via-blue-50 to-cyan-100 dark:from-blue-900/40 dark:via-gray-800 dark:to-cyan-900/40"></div>
           <div className="relative z-10">
-            <div className="inline-flex items-center px-4 py-2 rounded-full bg-blue-100 text-blue-800 text-sm font-medium mb-6 animate-fade-in">
+            <div className="inline-flex items-center px-4 py-2 rounded-full bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-300 text-sm font-medium mb-6 animate-fade-in">
               🏠 대학생 전용 룸메이트 매칭
             </div>
-            <h1 className="text-5xl md:text-7xl font-bold text-gray-900 mb-6 animate-fade-in">
+            <h1 className="text-5xl md:text-7xl font-bold text-gray-900 dark:text-white mb-6 animate-fade-in">
               나와 맞는 룸메이트를
               <br />
               <span className="bg-gradient-to-r from-blue-600 to-cyan-600 bg-clip-text text-transparent">
                 찾아보세요
               </span>
             </h1>
-            <p className="text-xl md:text-2xl text-gray-600 mb-12 max-w-3xl mx-auto leading-relaxed animate-fade-in">
+            <p className="text-xl md:text-2xl text-gray-600 dark:text-gray-400 mb-12 max-w-3xl mx-auto leading-relaxed animate-fade-in">
               AI 기반 매칭 알고리즘으로
               <br />
-              <span className="font-semibold text-gray-800">생활 습관과 성격</span>을 고려한
+              <span className="font-semibold text-gray-800 dark:text-gray-200">생활 습관과 성격</span>을 고려한
               <br />
               완벽한 룸메이트를 만나보세요
             </p>
@@ -91,7 +118,9 @@ export default function Home() {
                 onClick={handleCreateProfileClick}
                 disabled={isLoading}
               >
-                {isLoggedIn && hasProfile ? '👀 내 프로필 보기' : '✨ 프로필 만들기'}
+                {isLoggedIn 
+                  ? (hasProfile ? '👀 내 프로필 보기' : '✨ 프로필 만들기')
+                  : '✨ 프로필 만들기'}
               </Button>
               <Button 
                 variant="outline" 
@@ -100,8 +129,51 @@ export default function Home() {
                 onClick={handleLoginClick}
                 disabled={isLoading}
               >
-                {isLoggedIn ? '📊 대시보드로 이동' : '🔑 로그인'}
+                {isLoggedIn 
+                  ? (hasProfile ? '📊 매칭 보기' : '✨ 프로필 만들기')
+                  : '🔑 로그인'}
               </Button>
+            </div>
+          </div>
+        </section>
+
+        {/* CTA 섹션 */}
+        <section className="relative py-24 px-8 text-center overflow-hidden">
+          <div className="absolute inset-0 bg-gradient-to-br from-blue-600 via-purple-600 to-cyan-600 opacity-90"></div>
+          <div className="absolute inset-0 bg-black opacity-20"></div>
+          <div className="relative z-10">
+            <div className="inline-flex items-center px-4 py-2 rounded-full bg-white/20 text-white text-sm font-medium mb-6 backdrop-blur-sm border border-white/30">
+              💡 왜 Unimate인가요?
+            </div>
+            <h2 className="text-4xl md:text-6xl font-bold text-white mb-6">
+              안전하고 신뢰할 수 있는
+              <br />
+              <span className="text-yellow-300">매칭 플랫폼</span>
+            </h2>
+            <p className="text-xl text-white/90 mb-12 max-w-3xl mx-auto leading-relaxed">
+              대학생 인증 시스템과 AI 기반 매칭으로
+              <br />
+              당신에게 가장 적합한 룸메이트를 추천합니다
+            </p>
+            
+            {/* 특징 아이콘 그리드 */}
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto mt-12">
+              <div className="flex flex-col items-center p-4 bg-white/10 rounded-xl backdrop-blur-sm border border-white/20 hover:bg-white/20 transition-all duration-300">
+                <div className="text-3xl mb-2">⚡</div>
+                <div className="text-sm text-white/90 font-medium">빠른 매칭</div>
+              </div>
+              <div className="flex flex-col items-center p-4 bg-white/10 rounded-xl backdrop-blur-sm border border-white/20 hover:bg-white/20 transition-all duration-300">
+                <div className="text-3xl mb-2">🔒</div>
+                <div className="text-sm text-white/90 font-medium">안전 보장</div>
+              </div>
+              <div className="flex flex-col items-center p-4 bg-white/10 rounded-xl backdrop-blur-sm border border-white/20 hover:bg-white/20 transition-all duration-300">
+                <div className="text-3xl mb-2">🤖</div>
+                <div className="text-sm text-white/90 font-medium">AI 추천</div>
+              </div>
+              <div className="flex flex-col items-center p-4 bg-white/10 rounded-xl backdrop-blur-sm border border-white/20 hover:bg-white/20 transition-all duration-300">
+                <div className="text-3xl mb-2">💬</div>
+                <div className="text-sm text-white/90 font-medium">실시간 채팅</div>
+              </div>
             </div>
           </div>
         </section>
@@ -109,14 +181,14 @@ export default function Home() {
         {/* 기능 소개 섹션 */}
         <section className="py-20">
           <div className="text-center mb-16">
-            <div className="inline-flex items-center px-4 py-2 rounded-full bg-green-100 text-green-800 text-sm font-medium mb-4">
+            <div className="inline-flex items-center px-4 py-2 rounded-full bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300 text-sm font-medium mb-4">
               🚀 핵심 기능
             </div>
-            <h2 className="text-4xl md:text-5xl font-bold text-gray-900 mb-6">
+            <h2 className="text-4xl md:text-5xl font-bold text-gray-900 dark:text-white mb-6">
               Unimate의
               <span className="bg-gradient-to-r from-green-600 to-blue-600 bg-clip-text text-transparent"> 주요 기능</span>
             </h2>
-            <p className="text-xl text-gray-600 max-w-3xl mx-auto leading-relaxed">
+            <p className="text-xl text-gray-600 dark:text-gray-400 max-w-3xl mx-auto leading-relaxed">
               정교한 AI 매칭 알고리즘으로 당신에게 가장 적합한 룸메이트를 찾아드립니다.
             </p>
           </div>
@@ -133,7 +205,7 @@ export default function Home() {
               </CardDescription>
             </CardHeader>
             <CardContent>
-              <ul className="text-sm text-gray-600 space-y-3">
+              <ul className="text-sm text-gray-600 dark:text-gray-400 space-y-3">
                 <li className="flex items-center">
                   <span className="w-2 h-2 bg-blue-500 rounded-full mr-3"></span>
                   수면 시간 및 패턴
@@ -165,7 +237,7 @@ export default function Home() {
               </CardDescription>
             </CardHeader>
             <CardContent>
-              <ul className="text-sm text-gray-600 space-y-3">
+              <ul className="text-sm text-gray-600 dark:text-gray-400 space-y-3">
                 <li className="flex items-center">
                   <span className="w-2 h-2 bg-green-500 rounded-full mr-3"></span>
                   생활 습관 호환성 분석
@@ -197,7 +269,7 @@ export default function Home() {
               </CardDescription>
             </CardHeader>
             <CardContent>
-              <ul className="text-sm text-gray-600 space-y-3">
+              <ul className="text-sm text-gray-600 dark:text-gray-400 space-y-3">
                 <li className="flex items-center">
                   <span className="w-2 h-2 bg-purple-500 rounded-full mr-3"></span>
                   대학생 인증 시스템
@@ -209,56 +281,16 @@ export default function Home() {
                 <li className="flex items-center">
                   <span className="w-2 h-2 bg-purple-500 rounded-full mr-3"></span>
                   신고 및 차단 기능
-          </li>
+                </li>
                 <li className="flex items-center">
                   <span className="w-2 h-2 bg-purple-500 rounded-full mr-3"></span>
                   개인정보 보호
-          </li>
+                </li>
               </ul>
             </CardContent>
           </Card>
         </div>
       </section>
-
-        {/* CTA 섹션 */}
-        <section className="relative py-24 px-8 text-center overflow-hidden">
-          <div className="absolute inset-0 bg-gradient-to-br from-blue-600 via-purple-600 to-cyan-600 opacity-90"></div>
-          <div className="absolute inset-0 bg-black opacity-20"></div>
-          <div className="relative z-10">
-            <div className="inline-flex items-center px-4 py-2 rounded-full bg-white/20 text-white text-sm font-medium mb-6 backdrop-blur-sm">
-              🚀 지금 시작하세요
-            </div>
-            <h2 className="text-4xl md:text-6xl font-bold text-white mb-6">
-              완벽한 룸메이트를
-              <br />
-              <span className="text-yellow-300">지금 만나보세요</span>
-            </h2>
-            <p className="text-xl text-white/90 mb-12 max-w-3xl mx-auto leading-relaxed">
-              몇 분만에 프로필을 만들고,
-              <br />
-              AI가 추천하는 최적의 룸메이트를 찾아보세요.
-            </p>
-            <div className="flex flex-col sm:flex-row gap-6 justify-center">
-              <Button 
-                size="lg" 
-                className="bg-white text-blue-600 hover:bg-gray-100 text-lg px-8 py-4 font-semibold"
-                onClick={handleCreateProfileClick}
-                disabled={isLoading}
-              >
-                {isLoggedIn && hasProfile ? '👀 내 프로필 보기' : '✨ 무료로 시작하기'}
-              </Button>
-              <Button 
-                variant="outline" 
-                size="lg" 
-                className="border-white text-white hover:bg-white/10 text-lg px-8 py-4"
-                onClick={handleLoginClick}
-                disabled={isLoading}
-              >
-                {isLoggedIn ? '📊 대시보드로 이동' : '🔑 로그인'}
-              </Button>
-            </div>
-          </div>
-        </section>
       </div>
     </div>
   );

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -18,11 +18,11 @@ export default function ProfilePage() {
 
   return (
     <ProtectedRoute>
-      <div className="min-h-screen bg-[#F9FAFB]">
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
         <AppHeader />
         
         {/* Main Content */}
-        <div className="px-4 py-8">
+        <div className="max-w-7xl mx-auto px-4 py-8">
           <ProfileView onCreate={handleCreateProfile} onEdit={handleEditProfile} />
         </div>
       </div>

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -2,7 +2,7 @@ import RegisterForm from '@/components/auth/RegisterForm';
 
 export default function RegisterPage() {
   return (
-    <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center">
       <RegisterForm />
     </div>
   );

--- a/frontend/src/components/admin/AdminLoginForm.tsx
+++ b/frontend/src/components/admin/AdminLoginForm.tsx
@@ -51,13 +51,13 @@ const AdminLoginForm = () => {
   };
 
   return (
-    <div className="w-full max-w-md bg-white rounded-2xl shadow p-8">
+    <div className="w-full max-w-md bg-white dark:bg-gray-800 rounded-2xl shadow p-8">
       <div className="flex flex-col items-center mb-6">
-        <div className="bg-red-600 text-white w-12 h-12 rounded-full flex items-center justify-center font-bold text-xl mb-3">
+        <div className="bg-red-600 dark:bg-red-500 text-white w-12 h-12 rounded-full flex items-center justify-center font-bold text-xl mb-3">
           A
         </div>
-        <h2 className="text-xl font-semibold mb-1">관리자 로그인</h2>
-        <p className="text-sm text-gray-500 text-center">
+        <h2 className="text-xl font-semibold mb-1 text-gray-900 dark:text-white">관리자 로그인</h2>
+        <p className="text-sm text-gray-500 dark:text-gray-400 text-center">
           관리자 권한으로 시스템에 접근합니다.
         </p>
       </div>
@@ -65,7 +65,7 @@ const AdminLoginForm = () => {
       <form onSubmit={handleSubmit} className="space-y-4">
         {/* 이메일 */}
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
             관리자 이메일
           </label>
           <input
@@ -73,16 +73,16 @@ const AdminLoginForm = () => {
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             placeholder="admin@unimate.com"
-            className={`w-full border rounded-lg px-3 py-2 placeholder:text-gray-400 ${
-              errors.email ? 'border-red-500' : 'border-gray-300'
-            } focus:ring-2 focus:ring-red-500`}
+            className={`w-full bg-white dark:bg-gray-700 text-gray-900 dark:text-white border rounded-lg px-3 py-2 placeholder:text-gray-400 dark:placeholder:text-gray-500 ${
+              errors.email ? 'border-red-500' : 'border-gray-300 dark:border-gray-600'
+            } focus:ring-2 focus:ring-red-500 dark:focus:ring-red-400`}
           />
-          {errors.email && <p className="text-red-500 text-sm mt-1">{errors.email}</p>}
+          {errors.email && <p className="text-red-500 dark:text-red-400 text-sm mt-1">{errors.email}</p>}
         </div>
 
         {/* 비밀번호 */}
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
             비밀번호
           </label>
           <input
@@ -90,36 +90,36 @@ const AdminLoginForm = () => {
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             placeholder="비밀번호를 입력하세요"
-            className={`w-full border rounded-lg px-3 py-2 placeholder:text-gray-400 ${
-              errors.password ? 'border-red-500' : 'border-gray-300'
-            } focus:ring-2 focus:ring-red-500`}
+            className={`w-full bg-white dark:bg-gray-700 text-gray-900 dark:text-white border rounded-lg px-3 py-2 placeholder:text-gray-400 dark:placeholder:text-gray-500 ${
+              errors.password ? 'border-red-500' : 'border-gray-300 dark:border-gray-600'
+            } focus:ring-2 focus:ring-red-500 dark:focus:ring-red-400`}
           />
-          {errors.password && <p className="text-red-500 text-sm mt-1">{errors.password}</p>}
+          {errors.password && <p className="text-red-500 dark:text-red-400 text-sm mt-1">{errors.password}</p>}
         </div>
 
         {/* 에러 메시지 */}
-        {errors.form && <p className="text-red-500 text-sm">{errors.form}</p>}
+        {errors.form && <p className="text-red-500 dark:text-red-400 text-sm">{errors.form}</p>}
 
         {/* 로그인 버튼 */}
         <button
           type="submit"
           disabled={loading}
-          className="w-full bg-red-600 text-white py-2 rounded-lg mt-2 hover:bg-red-700 disabled:bg-gray-400"
+          className="w-full bg-red-600 dark:bg-red-500 text-white py-2 rounded-lg mt-2 hover:bg-red-700 dark:hover:bg-red-600 disabled:bg-gray-400 dark:disabled:bg-gray-600"
         >
           {loading ? '로그인 중...' : '관리자 로그인'}
         </button>
 
         {/* 회원가입 링크 */}
-        <div className="text-center text-sm text-gray-600 mt-6">
+        <div className="text-center text-sm text-gray-600 dark:text-gray-400 mt-6">
           관리자 계정이 없으신가요?{' '}
-          <Link href="/admin/signup" className="text-red-600 hover:underline font-medium">
+          <Link href="/admin/signup" className="text-red-600 dark:text-red-400 hover:underline font-medium">
             관리자 회원가입
           </Link>
         </div>
 
-        <div className="text-center text-sm text-gray-600 mt-2">
+        <div className="text-center text-sm text-gray-600 dark:text-gray-400 mt-2">
           일반 사용자이신가요?{' '}
-          <Link href="/login" className="text-blue-600 hover:underline font-medium">
+          <Link href="/login" className="text-blue-600 dark:text-blue-400 hover:underline font-medium">
             사용자 로그인
           </Link>
         </div>

--- a/frontend/src/components/admin/AdminSignupForm.tsx
+++ b/frontend/src/components/admin/AdminSignupForm.tsx
@@ -81,13 +81,13 @@ const AdminSignupForm = () => {
   };
 
   return (
-    <div className="w-full max-w-md bg-white rounded-2xl shadow p-8">
+    <div className="w-full max-w-md bg-white dark:bg-gray-800 rounded-2xl shadow p-8">
       <div className="flex flex-col items-center mb-6">
-        <div className="bg-red-600 text-white w-12 h-12 rounded-full flex items-center justify-center font-bold text-xl mb-3">
+        <div className="bg-red-600 dark:bg-red-500 text-white w-12 h-12 rounded-full flex items-center justify-center font-bold text-xl mb-3">
           A
         </div>
-        <h2 className="text-xl font-semibold mb-1">관리자 계정 만들기</h2>
-        <p className="text-sm text-gray-500 text-center">
+        <h2 className="text-xl font-semibold mb-1 text-gray-900 dark:text-white">관리자 계정 만들기</h2>
+        <p className="text-sm text-gray-500 dark:text-gray-400 text-center">
           관리자 권한으로 시스템을 관리할 수 있습니다.
         </p>
       </div>
@@ -95,7 +95,7 @@ const AdminSignupForm = () => {
       <form onSubmit={handleSubmit} className="space-y-4">
         {/* 이메일 */}
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
             관리자 이메일
           </label>
           <input
@@ -103,16 +103,16 @@ const AdminSignupForm = () => {
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             placeholder="admin@unimate.com"
-            className={`w-full border rounded-lg px-3 py-2 placeholder:text-gray-400 ${
-              errors.email ? 'border-red-500' : 'border-gray-300'
-            } focus:ring-2 focus:ring-red-500`}
+            className={`w-full bg-white dark:bg-gray-700 text-gray-900 dark:text-white border rounded-lg px-3 py-2 placeholder:text-gray-400 dark:placeholder:text-gray-500 ${
+              errors.email ? 'border-red-500' : 'border-gray-300 dark:border-gray-600'
+            } focus:ring-2 focus:ring-red-500 dark:focus:ring-red-400`}
           />
-          {errors.email && <p className="text-red-500 text-sm mt-1">{errors.email}</p>}
+          {errors.email && <p className="text-red-500 dark:text-red-400 text-sm mt-1">{errors.email}</p>}
         </div>
 
         {/* 이름 */}
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
             이름
           </label>
           <input
@@ -120,16 +120,16 @@ const AdminSignupForm = () => {
             value={name}
             onChange={(e) => setName(e.target.value)}
             placeholder="관리자 이름"
-            className={`w-full border rounded-lg px-3 py-2 placeholder:text-gray-400 ${
-              errors.name ? 'border-red-500' : 'border-gray-300'
-            } focus:ring-2 focus:ring-red-500`}
+            className={`w-full bg-white dark:bg-gray-700 text-gray-900 dark:text-white border rounded-lg px-3 py-2 placeholder:text-gray-400 dark:placeholder:text-gray-500 ${
+              errors.name ? 'border-red-500' : 'border-gray-300 dark:border-gray-600'
+            } focus:ring-2 focus:ring-red-500 dark:focus:ring-red-400`}
           />
-          {errors.name && <p className="text-red-500 text-sm mt-1">{errors.name}</p>}
+          {errors.name && <p className="text-red-500 dark:text-red-400 text-sm mt-1">{errors.name}</p>}
         </div>
 
         {/* 비밀번호 */}
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
             비밀번호
           </label>
           <input
@@ -137,16 +137,16 @@ const AdminSignupForm = () => {
             value={password}
             onChange={(e) => handlePasswordChange(e.target.value)}
             placeholder="비밀번호를 입력하세요"
-            className={`w-full border rounded-lg px-3 py-2 placeholder:text-gray-400 ${
-              errors.password ? 'border-red-500' : 'border-gray-300'
-            } focus:ring-2 focus:ring-red-500`}
+            className={`w-full bg-white dark:bg-gray-700 text-gray-900 dark:text-white border rounded-lg px-3 py-2 placeholder:text-gray-400 dark:placeholder:text-gray-500 ${
+              errors.password ? 'border-red-500' : 'border-gray-300 dark:border-gray-600'
+            } focus:ring-2 focus:ring-red-500 dark:focus:ring-red-400`}
           />
-          {errors.password && <p className="text-red-500 text-sm mt-1">{errors.password}</p>}
+          {errors.password && <p className="text-red-500 dark:text-red-400 text-sm mt-1">{errors.password}</p>}
         </div>
 
         {/* 비밀번호 확인 */}
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
             비밀번호 확인
           </label>
           <input
@@ -154,34 +154,32 @@ const AdminSignupForm = () => {
             value={confirmPassword}
             onChange={(e) => handleConfirmPasswordChange(e.target.value)}
             placeholder="비밀번호를 다시 입력하세요"
-            className={`w-full border rounded-lg px-3 py-2 placeholder:text-gray-400 ${
-              errors.confirmPassword ? 'border-red-500' : 'border-gray-300'
-            } focus:ring-2 focus:ring-red-500`}
+            className={`w-full bg-white dark:bg-gray-700 text-gray-900 dark:text-white border rounded-lg px-3 py-2 placeholder:text-gray-400 dark:placeholder:text-gray-500 ${
+              errors.confirmPassword ? 'border-red-500' : 'border-gray-300 dark:border-gray-600'
+            } focus:ring-2 focus:ring-red-500 dark:focus:ring-red-400`}
           />
           {errors.confirmPassword && (
-            <p className="text-red-500 text-sm mt-1">{errors.confirmPassword}</p>
+            <p className="text-red-500 dark:text-red-400 text-sm mt-1">{errors.confirmPassword}</p>
           )}
         </div>
 
         {/* 에러 메시지 */}
-        {errors.form && <p className="text-red-500 text-sm">{errors.form}</p>}
+        {errors.form && <p className="text-red-500 dark:text-red-400 text-sm">{errors.form}</p>}
 
         <button
           type="submit"
           disabled={loading}
-          className="w-full bg-red-600 text-white py-2 rounded-lg mt-4 hover:bg-red-700 disabled:bg-gray-400"
+          className="w-full bg-red-600 dark:bg-red-500 text-white py-2 rounded-lg mt-4 hover:bg-red-700 dark:hover:bg-red-600 disabled:bg-gray-400 dark:disabled:bg-gray-600"
         >
           {loading ? '가입 중...' : '관리자 계정 만들기'}
         </button>
 
-        <div className="text-center text-sm text-gray-600 mt-6">
+        <div className="text-center text-sm text-gray-600 dark:text-gray-400 mt-6">
           이미 관리자 계정이 있으신가요?{' '}
-          <Link href="/admin/login" className="text-red-600 hover:underline font-medium">
+          <Link href="/admin/login" className="text-red-600 dark:text-red-400 hover:underline font-medium">
             관리자 로그인
           </Link>
         </div>
-
-        
       </form>
     </div>
   );

--- a/frontend/src/components/admin/ReportCard.tsx
+++ b/frontend/src/components/admin/ReportCard.tsx
@@ -11,22 +11,32 @@ interface ReportCardProps {
 
 const getStatusStyle = (status: ReportSummary['status']) => {
   switch (status) {
-    case 'RECEIVED': return 'bg-blue-100 text-blue-800';
-    case 'IN_PROGRESS': return 'bg-yellow-100 text-yellow-800';
-    case 'RESOLVED': return 'bg-green-100 text-green-800';
-    case 'REJECTED': return 'bg-gray-100 text-gray-800';
-    default: return 'bg-gray-100 text-gray-800';
+    case 'RECEIVED': return 'bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-300';
+    case 'IN_PROGRESS': return 'bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-300';
+    case 'RESOLVED': return 'bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300';
+    case 'REJECTED': return 'bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-300';
+    default: return 'bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-300';
+  }
+};
+
+const getStatusText = (status: ReportSummary['status']) => {
+  switch (status) {
+    case 'RECEIVED': return '접수';
+    case 'IN_PROGRESS': return '처리 중';
+    case 'RESOLVED': return '처리 완료';
+    case 'REJECTED': return '반려';
+    default: return status;
   }
 };
 
 const ReportCard: FC<ReportCardProps> = ({ report, onClick }) => {
   return (
-    <Card onClick={onClick} className="cursor-pointer hover:bg-gray-50 transition-colors">
+    <Card onClick={onClick} className="cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors">
       <CardHeader>
         <div className="flex justify-between items-center">
           <CardTitle className="text-lg">신고 ID: {report.reportId}</CardTitle>
           <span className={`px-2 py-1 text-xs font-semibold rounded-full ${getStatusStyle(report.status)}`}>
-            {report.status}
+            {getStatusText(report.status)}
           </span>
         </div>
         <CardDescription>
@@ -36,12 +46,12 @@ const ReportCard: FC<ReportCardProps> = ({ report, onClick }) => {
       <CardContent>
         <div className="grid grid-cols-2 gap-4 text-sm">
           <div>
-            <p className="font-semibold">신고자</p>
-            <p>{report.reporterName}</p>
+            <p className="font-semibold text-gray-900 dark:text-white">신고자</p>
+            <p className="text-gray-700 dark:text-gray-300">{report.reporterName}</p>
           </div>
           <div>
-            <p className="font-semibold">피신고자</p>
-            <p>{report.reportedName}</p>
+            <p className="font-semibold text-gray-900 dark:text-white">피신고자</p>
+            <p className="text-gray-700 dark:text-gray-300">{report.reportedName}</p>
           </div>
         </div>
       </CardContent>

--- a/frontend/src/components/admin/ReportDetailModal.tsx
+++ b/frontend/src/components/admin/ReportDetailModal.tsx
@@ -74,15 +74,22 @@ const ReportDetailModal: FC<ReportDetailModalProps> = ({ reportId, onClose, onAc
         
         {isLoading && <div className="flex justify-center p-8"><LoadingSpinner /></div>}
         
-        {report && (
+        {error && !isLoading && (
+          <div className="text-center p-8">
+            <p className="text-red-500 dark:text-red-400 mb-4">오류: {error}</p>
+            <Button onClick={() => window.location.reload()}>다시 시도</Button>
+          </div>
+        )}
+        
+        {report && !isLoading && !error && (
           <>
             <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-2">
               <InfoSection title="신고 상태" data={report.status} />
               <InfoSection title="신고 유형" data={report.category} />
               <InfoSection title="신고 내용" data={report.content} preWrap />
-              <hr className="dark:border-gray-700"/>
+              <hr className="border-gray-200 dark:border-gray-700"/>
               <UserInfo title="신고자 정보" user={report.reporterInfo} />
-              <hr className="dark:border-gray-700"/>
+              <hr className="border-gray-200 dark:border-gray-700"/>
               <UserInfo title="피신고자 정보" user={report.reportedInfo} />
             </div>
 
@@ -91,7 +98,7 @@ const ReportDetailModal: FC<ReportDetailModalProps> = ({ reportId, onClose, onAc
                 <p><span className="font-bold">주의:</span> 조치를 취하면 신고가 자동으로 처리 완료됩니다.</p>
               </div>
               
-              {error && <p className="text-red-500 text-sm mb-4 text-center">{error}</p>}
+              {error && <p className="text-red-500 dark:text-red-400 text-sm mb-4 text-center">{error}</p>}
 
               <div className="flex justify-between items-center">
                 <Button variant="outline" onClick={onClose} disabled={isProcessing}>닫기</Button>
@@ -105,7 +112,7 @@ const ReportDetailModal: FC<ReportDetailModalProps> = ({ reportId, onClose, onAc
                     반려
                   </Button>
                   <Button
-                    variant="destructive"
+                    variant="danger"
                     onClick={() => handleAction('DEACTIVATE')}
                     disabled={isProcessing || isActionDisabled}
                     loading={isProcessing}

--- a/frontend/src/components/admin/ReportFilters.tsx
+++ b/frontend/src/components/admin/ReportFilters.tsx
@@ -19,18 +19,19 @@ const ReportFilters: FC<ReportFiltersProps> = ({ onFilterChange, initialFilters 
   };
 
   return (
-    <div className="p-4 bg-gray-50 rounded-lg mb-6 flex items-center gap-4">
+    <div className="p-4 bg-gray-50 dark:bg-gray-800 rounded-lg mb-6 flex flex-col sm:flex-row items-stretch sm:items-center gap-4">
       <Select
         value={status}
         onChange={(e: ChangeEvent<HTMLSelectElement>) => setStatus(e.target.value)}
-        className="w-48"
-      >
-        <option value="">전체 상태</option>
-        <option value="RECEIVED">접수</option>
-        <option value="IN_PROGRESS">처리 중</option>
-        <option value="RESOLVED">처리 완료</option>
-        <option value="REJECTED">반려</option>
-      </Select>
+        className="w-full sm:w-48"
+        options={[
+          { value: '', label: '전체 상태' },
+          { value: 'RECEIVED', label: '접수' },
+          { value: 'IN_PROGRESS', label: '처리 중' },
+          { value: 'RESOLVED', label: '처리 완료' },
+          { value: 'REJECTED', label: '반려' },
+        ]}
+      />
       <Input
         type="text"
         placeholder="신고자 또는 피신고자 이름 검색"
@@ -38,7 +39,7 @@ const ReportFilters: FC<ReportFiltersProps> = ({ onFilterChange, initialFilters 
         onChange={(e: ChangeEvent<HTMLInputElement>) => setKeyword(e.target.value)}
         className="flex-grow"
       />
-      <Button onClick={handleSearch}>검색</Button>
+      <Button onClick={handleSearch} className="w-full sm:w-auto">검색</Button>
     </div>
   );
 };

--- a/frontend/src/components/admin/ReportList.tsx
+++ b/frontend/src/components/admin/ReportList.tsx
@@ -39,9 +39,8 @@ const ReportList: FC = () => {
     return <div className="flex justify-center p-10"><LoadingSpinner /></div>;
   }
 
-
   if (error) {
-    return <div className="text-center p-10 text-red-500">오류: {error}</div>;
+    return <div className="text-center p-10 text-red-500 dark:text-red-400">오류: {error}</div>;
   }
 
   return (
@@ -59,8 +58,8 @@ const ReportList: FC = () => {
               />
             ))
           ) : (
-            <div className="text-center py-12 bg-white rounded-lg border border-gray-200">
-              <p className="text-gray-500">해당 조건의 신고 내역이 없습니다.</p>
+            <div className="text-center py-12 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
+              <p className="text-gray-500 dark:text-gray-400">해당 조건의 신고 내역이 없습니다.</p>
             </div>
           )}
         </div>

--- a/frontend/src/components/auth/LoginForm.tsx
+++ b/frontend/src/components/auth/LoginForm.tsx
@@ -53,13 +53,13 @@ const LoginForm = () => {
   };
 
   return (
-    <div className="w-full max-w-md bg-white rounded-2xl shadow p-8">
+    <div className="w-full max-w-md bg-white dark:bg-gray-800 rounded-2xl shadow p-8">
       <div className="flex flex-col items-center mb-6">
-        <div className="bg-blue-600 text-white w-12 h-12 rounded-full flex items-center justify-center font-bold text-xl mb-3">
+        <div className="bg-blue-600 dark:bg-blue-500 text-white w-12 h-12 rounded-full flex items-center justify-center font-bold text-xl mb-3">
           U
         </div>
-        <h2 className="text-xl font-semibold mb-1">로그인</h2>
-        <p className="text-sm text-gray-500 text-center">
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-1">로그인</h2>
+        <p className="text-sm text-gray-500 dark:text-gray-400 text-center">
           UniMate에 로그인하여 룸메이트를 찾아보세요
         </p>
       </div>
@@ -67,48 +67,48 @@ const LoginForm = () => {
       <form onSubmit={handleSubmit} className="space-y-4">
         {/* 이메일 */}
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">이메일</label>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">이메일</label>
           <input
             type="email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             placeholder="email@uni.ac.kr"
-            className={`w-full border rounded-lg px-3 py-2 placeholder:text-gray-400 ${errors.email ? 'border-red-500' : 'border-gray-300'
-              } focus:ring-2 focus:ring-blue-500`}
+            className={`w-full bg-white dark:bg-gray-700 text-gray-900 dark:text-white border rounded-lg px-3 py-2 placeholder:text-gray-400 dark:placeholder:text-gray-500 ${errors.email ? 'border-red-500' : 'border-gray-300 dark:border-gray-600'
+              } focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400`}
           />
-          {errors.email && <p className="text-red-500 text-sm mt-1">{errors.email}</p>}
+          {errors.email && <p className="text-red-500 dark:text-red-400 text-sm mt-1">{errors.email}</p>}
         </div>
 
         {/* 비밀번호 */}
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">비밀번호</label>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">비밀번호</label>
           <input
             type="password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             placeholder="비밀번호를 입력하세요"
-            className={`w-full border rounded-lg px-3 py-2 placeholder:text-gray-400 ${errors.password ? 'border-red-500' : 'border-gray-300'
-              } focus:ring-2 focus:ring-blue-500`}
+            className={`w-full bg-white dark:bg-gray-700 text-gray-900 dark:text-white border rounded-lg px-3 py-2 placeholder:text-gray-400 dark:placeholder:text-gray-500 ${errors.password ? 'border-red-500' : 'border-gray-300 dark:border-gray-600'
+              } focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400`}
           />
-          {errors.password && <p className="text-red-500 text-sm mt-1">{errors.password}</p>}
+          {errors.password && <p className="text-red-500 dark:text-red-400 text-sm mt-1">{errors.password}</p>}
         </div>
 
         {/* 에러 메시지 */}
-        {errors.form && <p className="text-red-500 text-sm">{errors.form}</p>}
+        {errors.form && <p className="text-red-500 dark:text-red-400 text-sm">{errors.form}</p>}
 
         {/* 로그인 버튼 */}
         <button
           type="submit"
           disabled={loading}
-          className="w-full bg-blue-600 text-white py-2 rounded-lg mt-2 hover:bg-blue-700 disabled:bg-gray-400"
+          className="w-full bg-blue-600 dark:bg-blue-500 text-white py-2 rounded-lg mt-2 hover:bg-blue-700 dark:hover:bg-blue-600 disabled:bg-gray-400 dark:disabled:bg-gray-600"
         >
           {loading ? '로그인 중...' : '로그인'}
         </button>
 
         {/* 회원가입 링크 */}
-        <div className="text-center text-sm text-gray-600 mt-6">
+        <div className="text-center text-sm text-gray-600 dark:text-gray-400 mt-6">
           계정이 없으신가요?{' '}
-          <Link href="/register" className="text-blue-600 hover:underline font-medium">
+          <Link href="/register" className="text-blue-600 dark:text-blue-400 hover:underline font-medium">
             회원가입
           </Link>
         </div>

--- a/frontend/src/components/auth/RegisterForm.tsx
+++ b/frontend/src/components/auth/RegisterForm.tsx
@@ -254,21 +254,21 @@ const RegisterForm = () => {
   };
 
   return (
-    <div className="w-full max-w-md bg-white rounded-2xl shadow p-8">
+    <div className="w-full max-w-md bg-white dark:bg-gray-800 rounded-2xl shadow p-8">
       <div className="flex flex-col items-center mb-6">
-        <div className="bg-blue-600 text-white w-12 h-12 rounded-full flex items-center justify-center font-bold text-xl mb-3">
+        <div className="bg-blue-600 dark:bg-blue-500 text-white w-12 h-12 rounded-full flex items-center justify-center font-bold text-xl mb-3">
           U
         </div>
-        <h2 className="text-xl font-semibold mb-1">계정 만들기</h2>
-        <p className="text-sm text-gray-500 text-center">
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-1">계정 만들기</h2>
+        <p className="text-sm text-gray-500 dark:text-gray-400 text-center">
           UniMate에 가입하여 완벽한 룸메이트를 찾아보세요.
         </p>
       </div>
 
       <form onSubmit={handleSubmit} className="space-y-4">
-        {/* ===== 대학교 (자동완성) ===== */}
+        {/* 대학교 */}
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">대학교</label>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">대학교</label>
           <div className="relative">
             <input
               type="text"
@@ -281,20 +281,20 @@ const RegisterForm = () => {
               }}
               placeholder="학교명을 입력하세요"
               disabled={isSchoolVerified || schoolsLoading}
-              className={`w-full border rounded-lg px-3 py-2 placeholder:text-gray-400 ${
-                errors.university ? 'border-red-500' : 'border-gray-300'
-              } focus:ring-2 focus:ring-blue-500 disabled:bg-gray-100`}
+              className={`w-full bg-white dark:bg-gray-700 text-gray-900 dark:text-white border rounded-lg px-3 py-2 placeholder:text-gray-400 dark:placeholder:text-gray-500 ${
+                errors.university ? 'border-red-500' : 'border-gray-300 dark:border-gray-600'
+              } focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400 disabled:bg-gray-100 dark:disabled:bg-gray-700`}
             />
 
             {/* 드롭다운 목록 */}
             {showDropdown && !isSchoolVerified && filteredSchools.length > 0 && (
-              <div className="absolute top-full left-0 right-0 bg-white border border-gray-300 rounded-lg mt-1 max-h-48 overflow-y-auto z-10 shadow-lg">
+              <div className="absolute top-full left-0 right-0 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg mt-1 max-h-48 overflow-y-auto z-10 shadow-lg">
                 {filteredSchools.slice(0, 100).map((school, idx) => (
                   <button
                     key={idx}
                     type="button"
                     onClick={() => handleSelectSchool(school)}
-                    className="w-full text-left px-3 py-2 hover:bg-blue-100 text-sm border-b border-gray-100 last:border-b-0 transition-colors"
+                    className="w-full text-left px-3 py-2 hover:bg-blue-100 dark:hover:bg-blue-900/30 text-gray-900 dark:text-white text-sm border-b border-gray-100 dark:border-gray-700 last:border-b-0 transition-colors"
                   >
                     {school.schoolName}
                   </button>
@@ -304,42 +304,33 @@ const RegisterForm = () => {
 
             {/* 검색 결과 없음 */}
             {showDropdown && !isSchoolVerified && university && filteredSchools.length === 0 && (
-              <div className="absolute top-full left-0 right-0 bg-white border border-gray-300 rounded-lg mt-1 z-10 shadow-lg">
-                <div className="px-3 py-4 text-center text-gray-500 text-sm">
+              <div className="absolute top-full left-0 right-0 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg mt-1 z-10 shadow-lg">
+                <div className="px-3 py-4 text-center text-gray-500 dark:text-gray-400 text-sm">
                   검색 결과가 없습니다.
                 </div>
               </div>
             )}
-
-            {/* 확인됨 표시 */}
-            {isSchoolVerified && (
-              <div className="absolute right-3 top-1/2 -translate-y-1/2">
-                <span className="bg-green-500 text-white px-2 py-1 rounded text-xs font-medium">
-                  확인됨
-                </span>
-              </div>
-            )}
           </div>
-          {errors.university && <p className="text-red-500 text-sm mt-1">{errors.university}</p>}
+          {errors.university && <p className="text-red-500 dark:text-red-400 text-sm mt-1">{errors.university}</p>}
         </div>
 
-        {/* ===== 이메일 ===== */}
+        {/* 이메일 */}
         {isSchoolVerified && (
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">이메일</label>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">이메일</label>
             <div className="flex space-x-2">
-              <div className="flex-1 flex border border-gray-300 rounded-lg overflow-hidden">
+              <div className="flex-1 flex border border-gray-300 dark:border-gray-600 rounded-lg overflow-hidden">
                 <input
                   type="text"
                   value={emailId}
                   onChange={(e) => setEmailId(e.target.value)}
                   placeholder="이메일 아이디"
                   disabled={isVerified}
-                  className={`flex-1 px-3 py-2 placeholder:text-gray-400 text-sm focus:outline-none disabled:bg-gray-100 ${
+                  className={`flex-1 px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder:text-gray-400 dark:placeholder:text-gray-500 text-sm focus:outline-none disabled:bg-gray-100 dark:disabled:bg-gray-700 ${
                     errors.emailId ? 'border-red-500' : ''
                   }`}
                 />
-                <span className="px-2 py-2 bg-gray-100 text-gray-600 text-sm font-medium border-l border-gray-300">
+                <span className="px-2 py-2 bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 text-sm font-medium border-l border-gray-300 dark:border-gray-600">
                   @{emailDomain}
                 </span>
               </div>
@@ -349,21 +340,21 @@ const RegisterForm = () => {
                 disabled={loading || isVerified}
                 className={`px-3 py-2 rounded-lg text-white text-sm font-medium whitespace-nowrap ${
                   isVerified
-                    ? 'bg-green-500 cursor-default'
-                    : 'bg-blue-600 hover:bg-blue-700'
+                    ? 'bg-green-500 dark:bg-green-600 cursor-default'
+                    : 'bg-blue-600 dark:bg-blue-500 hover:bg-blue-700 dark:hover:bg-blue-600'
                 } disabled:opacity-50`}
               >
                 {isCodeSent ? '재전송' : '전송'}
               </button>
             </div>
-            {errors.emailId && <p className="text-red-500 text-sm mt-1">{errors.emailId}</p>}
+            {errors.emailId && <p className="text-red-500 dark:text-red-400 text-sm mt-1">{errors.emailId}</p>}
           </div>
         )}
 
-        {/* ===== 인증번호 ===== */}
+        {/* 인증번호 */}
         {isCodeSent && !isVerified && (
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">인증번호</label>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">인증번호</label>
             <div className="flex space-x-2">
               <input
                 type="text"
@@ -371,147 +362,150 @@ const RegisterForm = () => {
                 onChange={handleCodeInput}
                 placeholder="인증번호 6자리"
                 maxLength={6}
-                className={`flex-1 border rounded-lg px-3 py-2 placeholder:text-gray-400 text-sm ${
-                  errors.code ? 'border-red-500' : 'border-gray-300'
-                } focus:ring-2 focus:ring-blue-500`}
+                className={`flex-1 bg-white dark:bg-gray-700 text-gray-900 dark:text-white border rounded-lg px-3 py-2 placeholder:text-gray-400 dark:placeholder:text-gray-500 text-sm ${
+                  errors.code ? 'border-red-500' : 'border-gray-300 dark:border-gray-600'
+                } focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400`}
               />
               <button
                 type="button"
                 onClick={handleVerifyCode}
                 disabled={loading}
-                className="bg-blue-600 text-white px-3 py-2 rounded-lg hover:bg-blue-700 text-sm font-medium whitespace-nowrap disabled:opacity-50"
+                className="bg-blue-600 dark:bg-blue-500 text-white px-3 py-2 rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 text-sm font-medium whitespace-nowrap disabled:opacity-50"
               >
                 확인
               </button>
             </div>
-            {errors.code && <p className="text-red-500 text-sm mt-1">{errors.code}</p>}
+            {errors.code && <p className="text-red-500 dark:text-red-400 text-sm mt-1">{errors.code}</p>}
           </div>
         )}
 
-        {/* ===== 비밀번호 ===== */}
+        {/* 비밀번호 */}
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">비밀번호</label>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">비밀번호</label>
           <input
             type="password"
             value={password}
             onChange={(e) => handlePasswordChange(e.target.value)}
             placeholder="비밀번호를 입력하세요"
-            className={`w-full border rounded-lg px-3 py-2 placeholder:text-gray-400 text-sm ${
-              errors.password ? 'border-red-500' : 'border-gray-300'
-            } focus:ring-2 focus:ring-blue-500`}
+            className={`w-full bg-white dark:bg-gray-700 text-gray-900 dark:text-white border rounded-lg px-3 py-2 placeholder:text-gray-400 dark:placeholder:text-gray-500 text-sm ${
+              errors.password ? 'border-red-500' : 'border-gray-300 dark:border-gray-600'
+            } focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400`}
           />
-          {errors.password && <p className="text-red-500 text-sm mt-1">{errors.password}</p>}
+          {errors.password && <p className="text-red-500 dark:text-red-400 text-sm mt-1">{errors.password}</p>}
         </div>
 
-        {/* ===== 비밀번호 확인 ===== */}
+        {/* 비밀번호 확인 */}
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">비밀번호 확인</label>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">비밀번호 확인</label>
           <input
             type="password"
             value={confirmPassword}
             onChange={(e) => handleConfirmPasswordChange(e.target.value)}
             placeholder="비밀번호를 다시 입력하세요"
-            className={`w-full border rounded-lg px-3 py-2 placeholder:text-gray-400 text-sm ${
-              errors.confirmPassword ? 'border-red-500' : 'border-gray-300'
-            } focus:ring-2 focus:ring-blue-500`}
+            className={`w-full bg-white dark:bg-gray-700 text-gray-900 dark:text-white border rounded-lg px-3 py-2 placeholder:text-gray-400 dark:placeholder:text-gray-500 text-sm ${
+              errors.confirmPassword ? 'border-red-500' : 'border-gray-300 dark:border-gray-600'
+            } focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400`}
           />
           {errors.confirmPassword && (
-            <p className="text-red-500 text-sm mt-1">{errors.confirmPassword}</p>
+            <p className="text-red-500 dark:text-red-400 text-sm mt-1">{errors.confirmPassword}</p>
           )}
         </div>
 
-        {/* ===== 이름 ===== */}
+        {/* 이름 */}
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">이름</label>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">이름</label>
           <input
             type="text"
             value={name}
             onChange={(e) => setName(e.target.value)}
             placeholder="홍길동"
-            className={`w-full border rounded-lg px-3 py-2 placeholder:text-gray-400 text-sm ${
-              errors.name ? 'border-red-500' : 'border-gray-300'
-            } focus:ring-2 focus:ring-blue-500`}
+            className={`w-full bg-white dark:bg-gray-700 text-gray-900 dark:text-white border rounded-lg px-3 py-2 placeholder:text-gray-400 dark:placeholder:text-gray-500 text-sm ${
+              errors.name ? 'border-red-500' : 'border-gray-300 dark:border-gray-600'
+            } focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400`}
           />
-          {errors.name && <p className="text-red-500 text-sm mt-1">{errors.name}</p>}
+          {errors.name && <p className="text-red-500 dark:text-red-400 text-sm mt-1">{errors.name}</p>}
         </div>
 
-        {/* ===== 생년월일 ===== */}
+        {/* 생년월일 */}
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">생년월일</label>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">생년월일</label>
           <input
             type="date"
             value={birthDate}
             max={new Date().toISOString().split('T')[0]}
             onChange={(e) => setBirthDate(e.target.value)}
-            className={`w-full border rounded-lg px-3 py-2 text-sm ${
-              errors.birthDate ? 'border-red-500' : 'border-gray-300'
-            } focus:ring-2 focus:ring-blue-500`}
+            className={`w-full bg-white dark:bg-gray-700 text-gray-900 dark:text-white border rounded-lg px-3 py-2 text-sm ${
+              errors.birthDate ? 'border-red-500' : 'border-gray-300 dark:border-gray-600'
+            } focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400`}
           />
           {errors.birthDate && (
-            <p className="text-red-500 text-sm mt-1">{errors.birthDate}</p>
+            <p className="text-red-500 dark:text-red-400 text-sm mt-1">{errors.birthDate}</p>
           )}
         </div>
 
-        {/* ===== 성별 ===== */}
+        {/* 성별 */}
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">성별</label>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">성별</label>
           <div className="flex space-x-4">
-            <label className="flex items-center space-x-2 text-sm">
+            <label className="flex items-center space-x-2 text-sm text-gray-900 dark:text-white">
               <input
                 type="radio"
                 name="gender"
                 value="MALE"
                 checked={gender === 'MALE'}
                 onChange={() => setGender(Gender.MALE)}
+                className="text-blue-600 dark:text-blue-400"
               />
               <span>남성</span>
             </label>
-            <label className="flex items-center space-x-2 text-sm">
+            <label className="flex items-center space-x-2 text-sm text-gray-900 dark:text-white">
               <input
                 type="radio"
                 name="gender"
                 value="FEMALE"
                 checked={gender === 'FEMALE'}
                 onChange={() => setGender(Gender.FEMALE)}
+                className="text-blue-600 dark:text-blue-400"
               />
               <span>여성</span>
             </label>
           </div>
-          {errors.gender && <p className="text-red-500 text-sm mt-1">{errors.gender}</p>}
+          {errors.gender && <p className="text-red-500 dark:text-red-400 text-sm mt-1">{errors.gender}</p>}
         </div>
 
-        {/* ===== 이용약관 ===== */}
+        {/* 이용약관 */}
         <div className="flex items-center space-x-2 text-sm">
           <input
             type="checkbox"
             checked={agree}
             onChange={(e) => setAgree(e.target.checked)}
+            className="text-blue-600 dark:text-blue-400"
           />
-          <label className="text-gray-600">
+          <label className="text-gray-600 dark:text-gray-400">
             이용약관 및 개인정보처리방침에 동의합니다
           </label>
         </div>
-        {errors.agree && <p className="text-red-500 text-sm">{errors.agree}</p>}
+        {errors.agree && <p className="text-red-500 dark:text-red-400 text-sm">{errors.agree}</p>}
 
-        {/* ===== 성공/에러 메시지 ===== */}
-        {message && <p className="text-blue-600 text-sm">{message}</p>}
-        {errors.form && <p className="text-red-500 text-sm">{errors.form}</p>}
+        {/* 성공/에러 메시지 */}
+        {message && <p className="text-blue-600 dark:text-blue-400 text-sm">{message}</p>}
+        {errors.form && <p className="text-red-500 dark:text-red-400 text-sm">{errors.form}</p>}
 
-        {/* ===== 제출 버튼 ===== */}
+        {/* 제출 버튼 */}
         <button
           type="submit"
           disabled={loading}
-          className="w-full bg-blue-600 text-white py-2 rounded-lg mt-4 hover:bg-blue-700 disabled:bg-gray-400 font-medium text-sm"
+          className="w-full bg-blue-600 dark:bg-blue-500 text-white py-2 rounded-lg mt-4 hover:bg-blue-700 dark:hover:bg-blue-600 disabled:bg-gray-400 dark:disabled:bg-gray-600 font-medium text-sm"
         >
           {loading ? '가입 중...' : '다음'}
         </button>
 
-        {/* ===== 로그인 링크 ===== */}
-        <div className="text-center text-xs text-gray-600 mt-4">
+        {/* 로그인 링크 */}
+        <div className="text-center text-xs text-gray-600 dark:text-gray-400 mt-4">
           이미 계정이 있으신가요?{" "}
           <Link
             href="/login"
-            className="text-blue-600 hover:underline font-medium"
+            className="text-blue-600 dark:text-blue-400 hover:underline font-medium"
           >
             로그인
           </Link>

--- a/frontend/src/components/chat/ChatRoomView.tsx
+++ b/frontend/src/components/chat/ChatRoomView.tsx
@@ -309,14 +309,14 @@ export default function ChatRoomView({ chatroomId }: ChatRoomViewProps) {
   }
 
   return (
-    <div className="h-screen bg-[#F9FAFB] flex flex-col relative">
+    <div className="h-screen bg-gray-50 dark:bg-gray-900 flex flex-col relative">
       <AppHeader />
       
       {/* Toast Message */}
       {toast && (
         <div className="fixed top-20 left-1/2 transform -translate-x-1/2 z-50 animate-fade-in">
           <div className={`px-6 py-3 rounded-lg shadow-lg ${
-            toast.type === 'success' ? 'bg-[#10B981] text-white' : 'bg-[#EF4444] text-white'
+            toast.type === 'success' ? 'bg-green-500 dark:bg-green-600 text-white' : 'bg-red-500 dark:bg-red-600 text-white'
           }`}>
             <p className="font-medium">{toast.message}</p>
           </div>
@@ -324,28 +324,28 @@ export default function ChatRoomView({ chatroomId }: ChatRoomViewProps) {
       )}
 
       {/* Chat Info Bar */}
-      <div className="bg-white border-b border-[#E5E7EB] flex-shrink-0">
+      <div className="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 flex-shrink-0">
         <div className="px-4 py-4">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-4">
               <button
                 onClick={() => router.back()}
-                className="p-2 hover:bg-gray-100 rounded-lg transition-colors"
+                className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
               >
-                <ArrowLeft className="w-5 h-5 text-gray-600" />
+                <ArrowLeft className="w-5 h-5 text-gray-600 dark:text-gray-400" />
               </button>
               <div>
-                <h2 className={`font-semibold ${isPartnerDeleted ? 'text-red-500' : 'text-[#111827]'}`}>
+                <h2 className={`font-semibold ${isPartnerDeleted ? 'text-red-500' : 'text-gray-900 dark:text-white'}`}>
                   {partnerName}
                 </h2>
                 {isPartnerDeleted ? (
-                  <p className="text-sm text-red-400">이 사용자는 탈퇴했습니다</p>
+                  <p className="text-sm text-red-400 dark:text-red-500">이 사용자는 탈퇴했습니다</p>
                 ) : isPartnerLeft ? (
-                  <p className="text-sm text-red-500">상대방이 채팅방에서 나갔습니다</p>
+                  <p className="text-sm text-red-500 dark:text-red-400">상대방이 채팅방에서 나갔습니다</p>
                 ) : isPartnerBlocked ? (
-                  <p className="text-sm text-orange-500">이 사용자를 차단했습니다</p>
+                  <p className="text-sm text-orange-500 dark:text-orange-400">이 사용자를 차단했습니다</p>
                 ) : (
-                  partnerInfo && <p className="text-sm text-[#6B7280]">{partnerInfo}</p>
+                  partnerInfo && <p className="text-sm text-gray-500 dark:text-gray-400">{partnerInfo}</p>
                 )}
               </div>
             </div>
@@ -355,12 +355,12 @@ export default function ChatRoomView({ chatroomId }: ChatRoomViewProps) {
               <div className="flex flex-col items-end gap-2">
                 {/* 상대방 응답 상태 표시 */}
                 {matchInfo.partnerResponse === 'ACCEPTED' && (
-                  <div className="bg-blue-50 text-blue-700 px-4 py-2 rounded-lg text-sm font-medium border border-blue-200 shadow-sm">
+                  <div className="bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 px-4 py-2 rounded-lg text-sm font-medium border border-blue-200 dark:border-blue-800 shadow-sm">
                     ⏰ 상대방이 확정을 기다리고 있습니다
                   </div>
                 )}
                 {matchInfo.partnerResponse === 'REJECTED' && (
-                  <div className="bg-red-50 text-red-700 px-4 py-2 rounded-lg text-sm font-medium border border-red-200 shadow-sm">
+                  <div className="bg-red-50 dark:bg-red-900/30 text-red-700 dark:text-red-300 px-4 py-2 rounded-lg text-sm font-medium border border-red-200 dark:border-red-800 shadow-sm">
                     ❌ 상대방이 거절했습니다
                   </div>
                 )}
@@ -370,11 +370,11 @@ export default function ChatRoomView({ chatroomId }: ChatRoomViewProps) {
                   <button
                     onClick={handleRejectMatch}
                     disabled={isProcessing}
-                    className="group relative px-5 py-2.5 bg-white border border-gray-300 rounded-xl hover:border-[#EF4444] hover:bg-[#FEF2F2] disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200 shadow-sm hover:shadow-md"
+                    className="group relative px-5 py-2.5 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-xl hover:border-red-500 dark:hover:border-red-500 hover:bg-red-50 dark:hover:bg-red-900/30 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200 shadow-sm hover:shadow-md"
                   >
                     <div className="flex items-center gap-2">
-                      <XCircle className="w-4 h-4 text-gray-600 group-hover:text-[#EF4444] transition-colors" />
-                      <span className="font-semibold text-sm text-gray-700 group-hover:text-[#EF4444] transition-colors">
+                      <XCircle className="w-4 h-4 text-gray-600 dark:text-gray-400 group-hover:text-red-500 dark:group-hover:text-red-400 transition-colors" />
+                      <span className="font-semibold text-sm text-gray-700 dark:text-gray-300 group-hover:text-red-500 dark:group-hover:text-red-400 transition-colors">
                         거절
                       </span>
                     </div>
@@ -382,7 +382,7 @@ export default function ChatRoomView({ chatroomId }: ChatRoomViewProps) {
                   <button
                     onClick={handleConfirmMatch}
                     disabled={isProcessing}
-                    className="group relative px-5 py-2.5 bg-gradient-to-r from-[#4F46E5] to-[#6366F1] text-white rounded-xl hover:from-[#4338CA] hover:to-[#4F46E5] disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200 shadow-md hover:shadow-lg"
+                    className="group relative px-5 py-2.5 bg-gradient-to-r from-blue-600 to-indigo-600 dark:from-blue-500 dark:to-indigo-500 text-white rounded-xl hover:from-blue-700 hover:to-indigo-700 dark:hover:from-blue-600 dark:hover:to-indigo-600 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200 shadow-md hover:shadow-lg"
                   >
                     <div className="flex items-center gap-2">
                       <CheckCircle className="w-4 h-4" />
@@ -406,7 +406,7 @@ export default function ChatRoomView({ chatroomId }: ChatRoomViewProps) {
       >
         <div className="space-y-4">
           {messages.length === 0 ? (
-            <div className="text-center text-gray-500 py-8">
+            <div className="text-center text-gray-500 dark:text-gray-400 py-8">
               아직 메시지가 없습니다. 첫 메시지를 보내보세요!
             </div>
           ) : (
@@ -428,14 +428,14 @@ export default function ChatRoomView({ chatroomId }: ChatRoomViewProps) {
                   <div
                     className={`max-w-md px-4 py-3 rounded-2xl ${
                       isMe
-                        ? 'bg-[#4F46E5] text-white'
-                        : 'bg-white border border-[#E5E7EB] text-[#111827]'
+                        ? 'bg-blue-600 dark:bg-blue-500 text-white'
+                        : 'bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 text-gray-900 dark:text-white'
                     }`}
                   >
                     <p className="mb-1">{m.content}</p>
                     <p
                       className={`text-xs ${
-                        isMe ? 'text-[#C7D2FE]' : 'text-[#9CA3AF]'
+                        isMe ? 'text-blue-200 dark:text-blue-300' : 'text-gray-500 dark:text-gray-400'
                       }`}
                     >
                       {messageTime}
@@ -455,7 +455,7 @@ export default function ChatRoomView({ chatroomId }: ChatRoomViewProps) {
         <div className="absolute bottom-28 left-1/2 transform -translate-x-1/2 z-20">
           <button
             onClick={scrollToBottom}
-            className="bg-[#4F46E5] text-white px-4 py-2 rounded-full shadow-lg hover:bg-[#4338CA] transition-colors flex items-center gap-2"
+            className="bg-blue-600 dark:bg-blue-500 text-white px-4 py-2 rounded-full shadow-lg hover:bg-blue-700 dark:hover:bg-blue-600 transition-colors flex items-center gap-2"
           >
             <span className="text-sm font-medium">새 메시지</span>
             <div className="w-2 h-2 bg-white rounded-full animate-pulse"></div>
@@ -464,22 +464,22 @@ export default function ChatRoomView({ chatroomId }: ChatRoomViewProps) {
       )}
 
       {/* Message Input */}
-      <div className="bg-white border-t border-[#E5E7EB] flex-shrink-0">
+      <div className="bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 flex-shrink-0">
         <div className="px-4 py-4">
           {isPartnerDeleted ? (
-            <div className="text-center py-4 text-gray-500 bg-gray-50 rounded-xl">
+            <div className="text-center py-4 text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-800 rounded-xl">
               <p className="text-sm">탈퇴한 사용자와는 메시지를 주고받을 수 없습니다</p>
             </div>
           ) : isPartnerLeft ? (
-            <div className="text-center py-4 text-gray-500 bg-gray-50 rounded-xl">
+            <div className="text-center py-4 text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-800 rounded-xl">
               <p className="text-sm">상대방이 채팅방에서 나갔습니다</p>
             </div>
           ) : isPartnerBlocked ? (
-            <div className="text-center py-4 text-orange-500 bg-orange-50 rounded-xl border border-orange-200">
+            <div className="text-center py-4 text-orange-500 dark:text-orange-400 bg-orange-50 dark:bg-orange-900/30 rounded-xl border border-orange-200 dark:border-orange-800">
               <p className="text-sm font-medium">차단된 사용자입니다. 메시지를 보낼 수 없습니다.</p>
             </div>
           ) : isBlockedByPartner ? (
-            <div className="text-center py-4 text-gray-500 bg-gray-50 rounded-xl">
+            <div className="text-center py-4 text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-800 rounded-xl">
               <p className="text-sm font-medium">메시지를 보낼 수 없습니다.</p>
             </div>
           ) : (
@@ -494,12 +494,12 @@ export default function ChatRoomView({ chatroomId }: ChatRoomViewProps) {
                     sendMessage(text)
                   }
                 }}
-                className="flex-1 px-4 py-3 border border-[#E5E7EB] rounded-xl focus:outline-none focus:ring-2 focus:ring-[#4F46E5] focus:border-transparent"
+                className="flex-1 px-4 py-3 bg-white dark:bg-gray-800 text-gray-900 dark:text-white border border-gray-200 dark:border-gray-700 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-600 dark:focus:ring-blue-500 focus:border-transparent placeholder:text-gray-400 dark:placeholder:text-gray-500"
               />
               <button
                 onClick={() => sendMessage(text)}
                 disabled={!text.trim()}
-                className="w-12 h-12 bg-[#4F46E5] text-white rounded-xl flex items-center justify-center hover:bg-[#4338CA] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                className="w-12 h-12 bg-blue-600 dark:bg-blue-500 text-white rounded-xl flex items-center justify-center hover:bg-blue-700 dark:hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
               >
                 <Send className="w-5 h-5" />
               </button>

--- a/frontend/src/components/layout/AdminHeader.tsx
+++ b/frontend/src/components/layout/AdminHeader.tsx
@@ -27,14 +27,14 @@ export default function AdminHeader() {
   ];
 
   return (
-    <header className="bg-white shadow-md sticky top-0 z-20">
+    <header className="bg-white dark:bg-gray-800 shadow-md sticky top-0 z-20 border-b border-gray-200 dark:border-gray-700">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3 flex justify-between items-center">
         {/* Left side: Title */}
         <Link href="/admin/dashboard" className="flex items-center gap-2">
-          <div className="w-8 h-8 bg-slate-800 rounded-lg flex items-center justify-center">
+          <div className="w-8 h-8 bg-slate-800 dark:bg-slate-700 rounded-lg flex items-center justify-center">
             <Shield className="w-5 h-5 text-white" />
           </div>
-          <span className="text-xl font-bold text-slate-800">Admin</span>
+          <span className="text-xl font-bold text-slate-800 dark:text-white">Admin</span>
         </Link>
 
         {/* Right side: Nav, User Info, Logout */}
@@ -49,8 +49,8 @@ export default function AdminHeader() {
                   href={item.key}
                   className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg transition-colors text-sm ${
                     isActive
-                      ? 'bg-slate-100 text-slate-900 font-semibold'
-                      : 'text-gray-600 hover:bg-slate-50'
+                      ? 'bg-slate-100 dark:bg-slate-700 text-slate-900 dark:text-white font-semibold'
+                      : 'text-gray-600 dark:text-gray-400 hover:bg-slate-50 dark:hover:bg-slate-700'
                   }`}
                 >
                   <Icon className="w-4 h-4" />
@@ -60,11 +60,11 @@ export default function AdminHeader() {
             })}
           </nav>
           
-          <div className="flex items-center gap-3 border-l border-gray-200 pl-6">
-            <span className="text-sm text-gray-600 hidden sm:block">{adminEmail}</span>
+          <div className="flex items-center gap-3 border-l border-gray-200 dark:border-gray-700 pl-6">
+            <span className="text-sm text-gray-600 dark:text-gray-400 hidden sm:block">{adminEmail}</span>
             <button
               onClick={handleLogout}
-              className="px-3 py-1.5 bg-red-600 text-white text-sm rounded-lg hover:bg-red-700 transition-colors"
+              className="px-3 py-1.5 bg-red-600 dark:bg-red-500 text-white text-sm rounded-lg hover:bg-red-700 dark:hover:bg-red-600 transition-colors"
             >
               로그아웃
             </button>

--- a/frontend/src/components/layout/AppHeader.tsx
+++ b/frontend/src/components/layout/AppHeader.tsx
@@ -106,9 +106,9 @@ export default function AppHeader() {
 
   if (isLoading) {
     return (
-      <header className="bg-white border-b border-[#E5E7EB] sticky top-0 z-20">
+      <header className="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 sticky top-0 z-20">
         <div className="max-w-7xl mx-auto px-4 py-3 flex items-center justify-center">
-          <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-[#4F46E5]"></div>
+          <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-600 dark:border-blue-500"></div>
         </div>
       </header>
     )
@@ -116,13 +116,13 @@ export default function AppHeader() {
 
   if (!isAuthenticated) {
     return (
-      <header className="bg-white border-b border-[#E5E7EB] sticky top-0 z-20">
+      <header className="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 sticky top-0 z-20">
         <div className="max-w-7xl mx-auto px-4 py-3 flex items-center justify-between">
           <Link href="/" className="flex items-center gap-2 hover:opacity-80 transition-opacity">
-            <div className="w-8 h-8 bg-[#4F46E5] rounded-lg flex items-center justify-center">
+            <div className="w-8 h-8 bg-blue-600 dark:bg-blue-500 rounded-lg flex items-center justify-center">
               <span className="text-white font-bold text-sm">U</span>
             </div>
-            <span className="text-xl font-bold text-[#4F46E5]">UniMate</span>
+            <span className="text-xl font-bold text-blue-600 dark:text-blue-400">UniMate</span>
           </Link>
 
           <div className="flex items-center gap-3">
@@ -132,7 +132,7 @@ export default function AppHeader() {
               </button>
             </Link>
             <Link href="/register">
-              <button className="px-4 py-2 bg-[#4F46E5] text-white hover:bg-[#4338CA] rounded-lg transition-colors">
+              <button className="px-4 py-2 bg-blue-600 dark:bg-blue-500 text-white hover:bg-blue-700 dark:hover:bg-blue-600 rounded-lg transition-colors">
                 회원가입
               </button>
             </Link>
@@ -143,16 +143,16 @@ export default function AppHeader() {
   }
 
   return (
-    <header className="bg-white border-b border-[#E5E7EB] sticky top-0 z-20">
+    <header className="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 sticky top-0 z-20">
       <div className="max-w-7xl mx-auto px-4 py-3 flex items-center justify-between">
         <button 
           onClick={() => router.push('/')}
           className="flex items-center gap-2 hover:opacity-80 transition-opacity"
         >
-          <div className="w-8 h-8 bg-[#4F46E5] rounded-lg flex items-center justify-center">
+          <div className="w-8 h-8 bg-blue-600 dark:bg-blue-500 rounded-lg flex items-center justify-center">
             <span className="text-white font-bold text-sm">U</span>
           </div>
-          <span className="text-xl font-bold text-[#4F46E5]">UniMate</span>
+          <span className="text-xl font-bold text-blue-600 dark:text-blue-400">UniMate</span>
         </button>
 
         <nav className="flex items-center gap-6">
@@ -166,8 +166,8 @@ export default function AppHeader() {
                 onClick={() => router.push(item.key)}
                 className={`flex items-center gap-1 px-3 py-1 rounded-lg transition-colors ${
                   isActive
-                    ? 'text-[#4F46E5] bg-[#EEF2FF] font-semibold'
-                    : 'text-[#6B7280] hover:bg-gray-50'
+                    ? 'text-blue-600 dark:text-blue-400 bg-blue-100 dark:bg-blue-900 font-semibold'
+                    : 'text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700'
                 }`}
               >
                 <Icon className="w-4 h-4" />
@@ -184,7 +184,7 @@ export default function AppHeader() {
             className="p-1 hover:bg-gray-100 rounded-lg transition-colors"
             title="후기"
           >
-            <Star className="w-5 h-5 text-[#F59E0B]" />
+            <Star className="w-5 h-5 text-yellow-500 dark:text-yellow-400" />
           </button>
           
           <div className="relative flex items-center">
@@ -193,10 +193,10 @@ export default function AppHeader() {
               className="p-1 hover:bg-gray-100 rounded-lg transition-colors"
               title="알림"
             >
-              <Bell className="w-5 h-5 text-[#6B7280]" />
+              <Bell className="w-5 h-5 text-gray-500 dark:text-gray-400" />
             </button>
             {unreadCount > 0 && (
-              <div className="absolute -top-1 -right-1 w-4 h-4 bg-[#4F46E5] text-white text-xs rounded-full flex items-center justify-center">
+              <div className="absolute -top-1 -right-1 w-4 h-4 bg-blue-600 dark:bg-blue-500 text-white text-xs rounded-full flex items-center justify-center">
                 {unreadCount > 99 ? '99+' : unreadCount}
               </div>
             )}
@@ -207,7 +207,7 @@ export default function AppHeader() {
             className="flex items-center hover:bg-gray-100 rounded-lg transition-colors"
             title="로그아웃"
           >
-            <LogOut className="w-5 h-5 text-[#6B7280]" />
+            <LogOut className="w-5 h-5 text-gray-500 dark:text-gray-400" />
           </button>
         </div>
       </div>
@@ -239,15 +239,15 @@ export default function AppHeader() {
                 leaveFrom="opacity-100 translate-x-0"
                 leaveTo="opacity-0 translate-x-full"
               >
-                <Dialog.Panel className="h-full w-full max-w-md bg-white shadow-2xl overflow-y-auto">
-                  <div className="sticky top-0 bg-white border-b border-gray-200 p-6 z-10">
+                <Dialog.Panel className="h-full w-full max-w-md bg-white dark:bg-gray-800 shadow-2xl overflow-y-auto">
+                  <div className="sticky top-0 bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 p-6 z-10">
                     <div className="flex items-center justify-between mb-2">
-                      <Dialog.Title className="text-2xl font-bold text-gray-900">
+                      <Dialog.Title className="text-2xl font-bold text-gray-900 dark:text-white">
                         리뷰
                       </Dialog.Title>
                       <button
                         onClick={() => setIsReviewModalOpen(false)}
-                        className="text-gray-400 hover:text-gray-600 transition-colors p-1"
+                        className="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition-colors p-1"
                       >
                         <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -256,13 +256,13 @@ export default function AppHeader() {
                     </div>
                     
                     {/* 탭 추가 */}
-                    <div className="flex gap-2 mt-4 border-b border-gray-200">
+                    <div className="flex gap-2 mt-4 border-b border-gray-200 dark:border-gray-700">
                       <button
                         onClick={() => setReviewTab('pending')}
                         className={`px-4 py-2 text-sm font-medium transition-colors ${
                           reviewTab === 'pending'
-                            ? 'text-[#4F46E5] border-b-2 border-[#4F46E5]'
-                            : 'text-gray-500 hover:text-gray-700'
+                            ? 'text-blue-600 dark:text-blue-400 border-b-2 border-blue-600 dark:border-blue-400'
+                            : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
                         }`}
                       >
                         대기 중인 리뷰
@@ -271,8 +271,8 @@ export default function AppHeader() {
                         onClick={() => setReviewTab('written')}
                         className={`px-4 py-2 text-sm font-medium transition-colors ${
                           reviewTab === 'written'
-                            ? 'text-[#4F46E5] border-b-2 border-[#4F46E5]'
-                            : 'text-gray-500 hover:text-gray-700'
+                            ? 'text-blue-600 dark:text-blue-400 border-b-2 border-blue-600 dark:border-blue-400'
+                            : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
                         }`}
                       >
                         작성된 리뷰

--- a/frontend/src/components/layout/PageContainer.tsx
+++ b/frontend/src/components/layout/PageContainer.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { cn } from '@/lib/utils/helpers';
+
+interface PageContainerProps {
+    children: React.ReactNode;
+    maxWidth?: 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '6xl' | '7xl' | 'full';
+    className?: string;
+}
+
+const maxWidthClasses = {
+    sm: 'max-w-sm',
+    md: 'max-w-md',
+    lg: 'max-w-lg',
+    xl: 'max-w-xl',
+    '2xl': 'max-w-2xl',
+    '6xl': 'max-w-6xl',
+    '7xl': 'max-w-7xl',
+    full: 'max-w-full',
+};
+
+export default function PageContainer({
+    children,
+    maxWidth = '7xl',
+    className
+}: PageContainerProps) {
+    return (
+        <div className={cn(
+            'min-h-screen bg-gray-50 dark:bg-gray-900',
+            className
+        )}>
+            <div className={cn(
+                maxWidthClasses[maxWidth],
+                'mx-auto px-4 py-8'
+            )}>
+                {children}
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/components/matches/MatchDetailModal.tsx
+++ b/frontend/src/components/matches/MatchDetailModal.tsx
@@ -165,16 +165,16 @@ const MatchDetailModal: FC<MatchDetailModalProps> = ({ isOpen, onClose, match, o
       {toast && (
         <div className="fixed top-20 right-6 z-[60] max-w-sm animate-slide-in-right">
           <div className={`rounded-lg p-4 shadow-2xl ${
-            toast.type === 'success' ? 'bg-green-50 border-2 border-green-200' :
-            toast.type === 'info' ? 'bg-blue-50 border-2 border-blue-200' :
-            'bg-red-50 border-2 border-red-200'
+            toast.type === 'success' ? 'bg-green-50 dark:bg-green-900/20 border-2 border-green-200 dark:border-green-800' :
+            toast.type === 'info' ? 'bg-blue-50 dark:bg-blue-900/20 border-2 border-blue-200 dark:border-blue-800' :
+            'bg-red-50 dark:bg-red-900/20 border-2 border-red-200 dark:border-red-800'
           }`}>
             <div className="flex items-start">
               <svg 
                 className={`w-5 h-5 mr-3 flex-shrink-0 ${
-                  toast.type === 'success' ? 'text-green-600' :
-                  toast.type === 'info' ? 'text-blue-600' :
-                  'text-red-600'
+                  toast.type === 'success' ? 'text-green-600 dark:text-green-400' :
+                  toast.type === 'info' ? 'text-blue-600 dark:text-blue-400' :
+                  'text-red-600 dark:text-red-400'
                 }`}
                 fill="currentColor" 
                 viewBox="0 0 20 20"
@@ -188,9 +188,9 @@ const MatchDetailModal: FC<MatchDetailModalProps> = ({ isOpen, onClose, match, o
                 )}
               </svg>
               <p className={`text-sm font-medium ${
-                toast.type === 'success' ? 'text-green-800' :
-                toast.type === 'info' ? 'text-blue-800' :
-                'text-red-800'
+                toast.type === 'success' ? 'text-green-800 dark:text-green-300' :
+                toast.type === 'info' ? 'text-blue-800 dark:text-blue-300' :
+                'text-red-800 dark:text-red-300'
               }`}>
                 {toast.message}
               </p>
@@ -210,7 +210,7 @@ const MatchDetailModal: FC<MatchDetailModalProps> = ({ isOpen, onClose, match, o
             <span className="text-gray-300">•</span>
             <span>{match.gender === 'MALE' ? '남학생' : '여학생'} · {match.age}세</span>
             <span className="text-gray-300">•</span>
-            <span className="text-[#4F46E5] font-semibold">매칭률 {Math.round((match.preferenceScore || 0) * 100)}%</span>
+            <span className="text-indigo-600 dark:text-indigo-400 font-semibold">매칭률 {Math.round((match.preferenceScore || 0) * 100)}%</span>
           </div>
         </div>
 
@@ -272,7 +272,7 @@ const MatchDetailModal: FC<MatchDetailModalProps> = ({ isOpen, onClose, match, o
             <button
               onClick={handleLikeClick}
               disabled={isLiking}
-              className="flex-1 py-3 rounded-lg font-medium transition-colors flex items-center justify-center gap-2 bg-[#EF4444] text-white hover:bg-[#DC2626] disabled:opacity-50 disabled:cursor-not-allowed"
+              className="flex-1 py-3 rounded-lg font-medium transition-colors flex items-center justify-center gap-2 bg-red-600 dark:bg-red-500 text-white hover:bg-red-700 dark:hover:bg-red-600 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {isLiking ? (
                 <>
@@ -295,7 +295,7 @@ const MatchDetailModal: FC<MatchDetailModalProps> = ({ isOpen, onClose, match, o
             <button
               onClick={handleLikeClick}
               disabled={isLiking}
-              className="flex-1 py-3 rounded-lg font-medium transition-colors flex items-center justify-center gap-2 bg-white text-gray-700 border border-gray-300 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="flex-1 py-3 rounded-lg font-medium transition-colors flex items-center justify-center gap-2 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {isLiking ? (
                 <>
@@ -318,7 +318,7 @@ const MatchDetailModal: FC<MatchDetailModalProps> = ({ isOpen, onClose, match, o
           
           <button
             onClick={() => setIsReportModalOpen(true)}
-            className="px-6 py-3 border border-[#E5E7EB] text-[#6B7280] rounded-lg hover:bg-[#F9FAFB] transition-colors flex items-center gap-2"
+            className="px-6 py-3 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors flex items-center gap-2"
           >
             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-5 h-5">
               <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"></path>

--- a/frontend/src/components/matches/MatchFilters.tsx
+++ b/frontend/src/components/matches/MatchFilters.tsx
@@ -40,13 +40,13 @@ export const MatchFilters = ({
     <>
       {/* 수면 시간대 */}
       <div>
-        <label className="block text-sm font-medium text-[#111827] dark:text-white mb-2">
+        <label className="block text-sm font-medium text-gray-900 dark:text-white mb-2">
            수면 시간대
         </label>
         <Select
           value={filters.sleepPattern || ''}
           onChange={(e) => handleFilterChange('sleepPattern', e.target.value)}
-          className="w-full px-2.5 py-1.5 text-sm border border-[#E5E7EB] dark:border-gray-600 rounded focus:outline-none focus:ring-1 focus:ring-[#4F46E5] bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+          className="w-full px-2.5 py-1.5 text-sm border border-gray-200 dark:border-gray-600 rounded focus:outline-none focus:ring-1 focus:ring-blue-600 dark:focus:ring-blue-400 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
           options={[
             { value: '', label: '전체' },
             { value: 'very_early', label: '22시 이전' },
@@ -60,13 +60,13 @@ export const MatchFilters = ({
 
       {/* 청소 빈도 */}
       <div>
-        <label className="block text-sm font-medium text-[#111827] dark:text-white mb-2">
+        <label className="block text-sm font-medium text-gray-900 dark:text-white mb-2">
           청소 빈도
         </label>
         <Select
           value={filters.cleaningFrequency || ''}
           onChange={(e) => handleFilterChange('cleaningFrequency', e.target.value)}
-          className="w-full px-2.5 py-1.5 text-sm border border-[#E5E7EB] dark:border-gray-600 rounded focus:outline-none focus:ring-1 focus:ring-[#4F46E5] bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+          className="w-full px-2.5 py-1.5 text-sm border border-gray-200 dark:border-gray-600 rounded focus:outline-none focus:ring-1 focus:ring-blue-600 dark:focus:ring-blue-400 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
           options={[
             { value: '', label: '전체' },
             { value: 'daily', label: '매일' },
@@ -80,13 +80,13 @@ export const MatchFilters = ({
 
       {/* 나이대 */}
       <div>
-        <label className="block text-sm font-medium text-[#111827] dark:text-white mb-2">
+        <label className="block text-sm font-medium text-gray-900 dark:text-white mb-2">
            나이대
         </label>
         <Select
           value={filters.ageRange || ''}
           onChange={(e) => handleFilterChange('ageRange', e.target.value)}
-          className="w-full px-2.5 py-1.5 text-sm border border-[#E5E7EB] dark:border-gray-600 rounded focus:outline-none focus:ring-1 focus:ring-[#4F46E5] bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+          className="w-full px-2.5 py-1.5 text-sm border border-gray-200 dark:border-gray-600 rounded focus:outline-none focus:ring-1 focus:ring-blue-600 dark:focus:ring-blue-400 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
           options={[
             { value: '', label: '전체' },
             { value: '20-22', label: '20-22세' },
@@ -102,7 +102,7 @@ export const MatchFilters = ({
       <Button
         onClick={onApplyFilters}
         disabled={isLoading}
-        className="w-full bg-[#4F46E5] hover:bg-[#4338CA] text-white font-medium py-2 text-sm rounded transition-colors"
+        className="w-full bg-blue-600 dark:bg-blue-500 hover:bg-blue-700 dark:hover:bg-blue-600 text-white font-medium py-2 text-sm rounded transition-colors"
       >
         필터 적용
       </Button>

--- a/frontend/src/components/matches/UserCard.tsx
+++ b/frontend/src/components/matches/UserCard.tsx
@@ -88,7 +88,7 @@ const UserCard: FC<UserCardProps> = ({ user, onLikeChange, onViewDetail }) => {
         {onViewDetail && (
           <button
             onClick={() => onViewDetail(user.receiverId)}
-            className="absolute top-4 right-4 px-2.5 py-1 text-xs text-[#4F46E5] bg-white border border-[#4F46E5] rounded-md hover:bg-[#EEF2FF] transition-colors whitespace-nowrap z-10"
+            className="absolute top-4 right-4 px-2.5 py-1 text-xs text-blue-600 dark:text-blue-400 bg-white dark:bg-gray-800 border border-blue-600 dark:border-blue-500 rounded-md hover:bg-blue-50 dark:hover:bg-blue-900/30 transition-colors whitespace-nowrap z-10"
           >
             상세보기
           </button>
@@ -96,12 +96,12 @@ const UserCard: FC<UserCardProps> = ({ user, onLikeChange, onViewDetail }) => {
         <CardHeader>
           <div className="flex justify-between items-start pr-20">
             <div>
-              <CardTitle>{user.name} <span className="text-base font-normal text-gray-500">{user.age}세</span></CardTitle>
+              <CardTitle>{user.name} <span className="text-base font-normal text-gray-500 dark:text-gray-400">{user.age}세</span></CardTitle>
               <CardDescription>{user.university}</CardDescription>
             </div>
             <div className="text-right">
-              <p className="text-2xl font-bold text-[#4F46E5]">{Math.round((user.preferenceScore || 0) * 100)}%</p>
-              <p className="text-sm text-gray-500">매칭률</p>
+              <p className="text-2xl font-bold text-blue-600 dark:text-blue-400">{Math.round((user.preferenceScore || 0) * 100)}%</p>
+              <p className="text-sm text-gray-500 dark:text-gray-400">매칭률</p>
             </div>
           </div>
         </CardHeader>
@@ -109,40 +109,40 @@ const UserCard: FC<UserCardProps> = ({ user, onLikeChange, onViewDetail }) => {
           <div className="space-y-3">
             {/* 기본 태그 */}
             <div className="flex flex-wrap gap-2">
-              <span className="px-3 py-1 bg-indigo-50 text-indigo-700 text-xs font-semibold rounded-full">
+              <span className="px-3 py-1 bg-indigo-50 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300 text-xs font-semibold rounded-full">
                 {user.gender === 'MALE' ? '남학생' : '여학생'}
               </span>
-              <span className="px-3 py-1 bg-gray-100 text-gray-700 text-xs font-semibold rounded-full">
+              <span className="px-3 py-1 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 text-xs font-semibold rounded-full">
                 {user.isSmoker ? '🚬 흡연' : '🚭 비흡연'}
               </span>
               {user.mbti && (
-                <span className="px-3 py-1 bg-purple-50 text-purple-700 text-xs font-semibold rounded-full">
+                <span className="px-3 py-1 bg-purple-50 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300 text-xs font-semibold rounded-full">
                   {user.mbti}
                 </span>
               )}
             </div>
 
             {/* 생활 패턴 정보 */}
-            <div className="grid grid-cols-2 gap-2 pt-2 border-t border-gray-100">
+            <div className="grid grid-cols-2 gap-2 pt-2 border-t border-gray-100 dark:border-gray-700">
               {getSleepTimeText(user.sleepTime) && (
                 <div className="flex items-center gap-1.5 text-xs">
-                  <span className="text-gray-500">🌙</span>
-                  <span className="text-gray-700 font-medium">{getSleepTimeText(user.sleepTime)}</span>
+                  <span className="text-gray-500 dark:text-gray-400">🌙</span>
+                  <span className="text-gray-700 dark:text-gray-300 font-medium">{getSleepTimeText(user.sleepTime)}</span>
                 </div>
               )}
               {getCleaningText(user.cleaningFrequency) && (
                 <div className="flex items-center gap-1.5 text-xs">
-                  <span className="text-gray-500">🧹</span>
-                  <span className="text-gray-700 font-medium">{getCleaningText(user.cleaningFrequency)}</span>
+                  <span className="text-gray-500 dark:text-gray-400">🧹</span>
+                  <span className="text-gray-700 dark:text-gray-300 font-medium">{getCleaningText(user.cleaningFrequency)}</span>
                 </div>
               )}
             </div>
 
             {/* 거주 기간 정보 */}
             {(user.startUseDate || user.endUseDate) && (
-              <div className="flex items-center gap-1.5 text-xs pt-2 border-t border-gray-100">
-                <span className="text-gray-500">룸셰어 기간</span>
-                <span className="text-gray-700 font-medium">
+              <div className="flex items-center gap-1.5 text-xs pt-2 border-t border-gray-100 dark:border-gray-700">
+                <span className="text-gray-500 dark:text-gray-400">룸셰어 기간</span>
+                <span className="text-gray-700 dark:text-gray-300 font-medium">
                   {user.startUseDate && new Date(user.startUseDate).toLocaleDateString('ko-KR', { year: '2-digit', month: 'short', day: 'numeric' })}
                   {user.startUseDate && user.endUseDate && ' ~ '}
                   {user.endUseDate && new Date(user.endUseDate).toLocaleDateString('ko-KR', { year: '2-digit', month: 'short', day: 'numeric' })}
@@ -156,7 +156,7 @@ const UserCard: FC<UserCardProps> = ({ user, onLikeChange, onViewDetail }) => {
             <button
               onClick={handleLikeClick}
               disabled={isLoading}
-              className="w-full py-3 rounded-lg font-medium transition-colors flex items-center justify-center gap-2 bg-[#EF4444] text-white hover:bg-[#DC2626] disabled:opacity-50 disabled:cursor-not-allowed"
+              className="w-full py-3 rounded-lg font-medium transition-colors flex items-center justify-center gap-2 bg-red-500 dark:bg-red-600 text-white hover:bg-red-600 dark:hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {isLoading ? (
                 <>
@@ -179,7 +179,7 @@ const UserCard: FC<UserCardProps> = ({ user, onLikeChange, onViewDetail }) => {
             <button
               onClick={handleLikeClick}
               disabled={isLoading}
-              className="w-full py-3 rounded-lg font-medium transition-colors flex items-center justify-center gap-2 bg-white text-gray-700 border border-gray-300 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="w-full py-3 rounded-lg font-medium transition-colors flex items-center justify-center gap-2 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {isLoading ? (
                 <>

--- a/frontend/src/components/notification/NotificationModal.tsx
+++ b/frontend/src/components/notification/NotificationModal.tsx
@@ -66,7 +66,7 @@ export default function NotificationModal({
         return (
           <button
             onClick={() => notification.senderId && onViewProfile(notification.senderId)}
-            className="text-blue-600 hover:text-blue-800 text-sm font-medium"
+            className="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 text-sm font-medium"
           >
             프로필 보기
           </button>
@@ -75,7 +75,7 @@ export default function NotificationModal({
         return (
           <button
             onClick={() => notification.chatroomId && onViewChat(notification.chatroomId)}
-            className="text-blue-600 hover:text-blue-800 text-sm font-medium"
+            className="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 text-sm font-medium"
           >
             채팅창으로 이동
           </button>
@@ -86,14 +86,12 @@ export default function NotificationModal({
             <button
               onClick={() => {
                 if (notification.chatroomId) {
-                  // chatroomId가 있으면 직접 채팅방으로 이동
                   window.location.href = `/chat/${notification.chatroomId}`;
                 } else {
-                  // chatroomId가 없으면 채팅 목록으로 이동
                   window.location.href = '/chat';
                 }
               }}
-              className="text-blue-600 hover:text-blue-800 text-sm font-medium"
+              className="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 text-sm font-medium"
             >
               채팅창으로 이동
             </button>
@@ -148,13 +146,13 @@ export default function NotificationModal({
       />
       
       {/* Notification Panel */}
-      <div className="fixed top-14 right-4 z-50 bg-white rounded-xl shadow-xl w-80 max-h-[70vh] overflow-hidden border border-gray-200 animate-in slide-in-from-top-2 duration-200">
+      <div className="fixed top-14 right-4 z-50 bg-white dark:bg-gray-800 rounded-xl shadow-xl w-80 max-h-[70vh] overflow-hidden border border-gray-200 dark:border-gray-700 animate-in slide-in-from-top-2 duration-200">
         {/* Header */}
-        <div className="px-6 py-4 border-b border-gray-200">
+        <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
           <div className="flex items-center justify-between">
             <div>
-              <h2 className="text-xl font-bold text-gray-900">알림</h2>
-              <p className="text-sm text-gray-500 mt-1">
+              <h2 className="text-xl font-bold text-gray-900 dark:text-white">알림</h2>
+              <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
                 오프라인 동안 받은 알림은 로그인 시 표시됩니다.
               </p>
             </div>
@@ -166,10 +164,10 @@ export default function NotificationModal({
                   onClose()
                 }
               }}
-              className="p-2 hover:bg-gray-100 rounded-lg transition-colors"
+              className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
               title={localNotifications.length > 0 ? "모든 알림 삭제" : "닫기"}
             >
-              <X className="w-5 h-5 text-gray-500" />
+              <X className="w-5 h-5 text-gray-500 dark:text-gray-400" />
             </button>
           </div>
         </div>
@@ -178,19 +176,19 @@ export default function NotificationModal({
         <div className="overflow-y-auto max-h-80">
           {localNotifications.length === 0 ? (
             <div className="px-6 py-12 text-center">
-              <div className="w-16 h-16 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4">
-                <MessageCircle className="w-8 h-8 text-gray-400" />
+              <div className="w-16 h-16 bg-gray-100 dark:bg-gray-700 rounded-full flex items-center justify-center mx-auto mb-4">
+                <MessageCircle className="w-8 h-8 text-gray-400 dark:text-gray-500" />
               </div>
-              <h3 className="text-lg font-medium text-gray-900 mb-2">알림이 없습니다</h3>
-              <p className="text-gray-500">새로운 알림이 오면 여기에 표시됩니다.</p>
+              <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-2">알림이 없습니다</h3>
+              <p className="text-gray-500 dark:text-gray-400">새로운 알림이 오면 여기에 표시됩니다.</p>
             </div>
           ) : (
-            <div className="divide-y divide-gray-200">
+            <div className="divide-y divide-gray-200 dark:divide-gray-700">
               {localNotifications.map((notification) => (
                 <div
                   key={notification.id}
-                  className={`px-6 py-4 hover:bg-gray-50 transition-colors cursor-pointer ${
-                    !notification.isRead ? 'bg-blue-50' : ''
+                  className={`px-6 py-4 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors cursor-pointer ${
+                    !notification.isRead ? 'bg-blue-50 dark:bg-blue-900/20' : ''
                   }`}
                   onClick={() => handleNotificationClick(notification)}
                 >
@@ -202,10 +200,10 @@ export default function NotificationModal({
 
                     {/* Content */}
                     <div className="flex-1 min-w-0">
-                      <p className="text-sm text-gray-900 mb-1">
+                      <p className="text-sm text-gray-900 dark:text-white mb-1">
                         {notification.message}
                       </p>
-                      <div className="flex items-center gap-2 text-xs text-gray-500 mb-2">
+                      <div className="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400 mb-2">
                         <Clock className="w-3 h-3" />
                         <span>{formatTime(notification.timestamp)}</span>
                       </div>
@@ -219,16 +217,16 @@ export default function NotificationModal({
                     {/* Actions */}
                     <div className="flex-shrink-0 flex items-center gap-2">
                       {!notification.isRead && (
-                        <div className="w-2 h-2 bg-red-500 rounded-full"></div>
+                        <div className="w-2 h-2 bg-red-500 dark:bg-red-400 rounded-full"></div>
                       )}
                       <button
                         onClick={(e) => {
                           e.stopPropagation()
                           onDeleteNotification(notification.id)
                         }}
-                        className="p-1 hover:bg-gray-200 rounded transition-colors"
+                        className="p-1 hover:bg-gray-200 dark:hover:bg-gray-600 rounded transition-colors"
                       >
-                        <X className="w-4 h-4 text-gray-400" />
+                        <X className="w-4 h-4 text-gray-400 dark:text-gray-500" />
                       </button>
                     </div>
                   </div>

--- a/frontend/src/components/profile/ProfileCard.tsx
+++ b/frontend/src/components/profile/ProfileCard.tsx
@@ -268,7 +268,7 @@ const ProfileCard: React.FC<ProfileCardProps> = ({
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <svg
-              className="w-5 h-5 text-blue-600"
+              className="w-5 h-5 text-blue-600 dark:text-blue-400"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -307,7 +307,7 @@ const ProfileCard: React.FC<ProfileCardProps> = ({
                     <button
                       onClick={handleNameUpdate}
                       disabled={isUpdatingName}
-                      className="px-3 py-1 bg-blue-600 text-white text-sm rounded hover:bg-blue-700 disabled:bg-gray-400 dark:disabled:bg-gray-600"
+                      className="px-3 py-1 bg-blue-600 dark:bg-blue-500 text-white text-sm rounded hover:bg-blue-700 dark:hover:bg-blue-600 disabled:bg-gray-400 dark:disabled:bg-gray-600"
                     >
                       {isUpdatingName ? '저장 중...' : '저장'}
                     </button>
@@ -325,7 +325,7 @@ const ProfileCard: React.FC<ProfileCardProps> = ({
                   <p className="text-gray-900 dark:text-white">{user.name}</p>
                   <button
                     onClick={() => setIsEditingName(true)}
-                    className="text-blue-600 hover:text-blue-700 text-sm"
+                    className="text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-500 text-sm"
                   >
                     <svg
                       className="w-4 h-4"
@@ -405,8 +405,8 @@ const ProfileCard: React.FC<ProfileCardProps> = ({
                       }
                       className={`px-4 py-2 text-white text-sm whitespace-nowrap ${
                         isEmailVerified
-                          ? 'bg-green-500 cursor-default'
-                          : 'bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400'
+                          ? 'bg-green-500 dark:bg-green-600 cursor-default'
+                          : 'bg-blue-600 dark:bg-blue-500 hover:bg-blue-700 dark:hover:bg-blue-600 disabled:bg-gray-400 dark:disabled:bg-gray-600'
                       }`}
                     >
                       {isEmailVerified ? '인증 완료' : isEmailCodeSent ? '인증번호 재전송' : '인증번호 전송'}
@@ -427,7 +427,7 @@ const ProfileCard: React.FC<ProfileCardProps> = ({
                       <button
                         onClick={handleVerifyEmailCode}
                         disabled={isUpdatingEmail}
-                        className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 whitespace-nowrap"
+                        className="px-4 py-2 bg-blue-600 dark:bg-blue-500 text-white rounded-md hover:bg-blue-700 dark:hover:bg-blue-600 whitespace-nowrap"
                       >
                         확인
                       </button>
@@ -436,10 +436,10 @@ const ProfileCard: React.FC<ProfileCardProps> = ({
 
                   {/* 에러/성공 메시지 */}
                   {emailError && (
-                    <p className="text-red-500 text-sm">{emailError}</p>
+                    <p className="text-red-500 dark:text-red-400 text-sm">{emailError}</p>
                   )}
                   {emailMessage && (
-                    <p className="text-blue-600 text-sm">{emailMessage}</p>
+                    <p className="text-blue-600 dark:text-blue-400 text-sm">{emailMessage}</p>
                   )}
 
                   {/* 저장/취소 버튼 */}
@@ -447,7 +447,7 @@ const ProfileCard: React.FC<ProfileCardProps> = ({
                     <button
                       onClick={handleEmailUpdate}
                       disabled={!isEmailVerified || isUpdatingEmail}
-                      className="flex-1 px-3 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:bg-gray-400 dark:disabled:bg-gray-600"
+                      className="flex-1 px-3 py-2 bg-blue-600 dark:bg-blue-500 text-white rounded hover:bg-blue-700 dark:hover:bg-blue-600 disabled:bg-gray-400 dark:disabled:bg-gray-600"
                     >
                       {isUpdatingEmail ? '변경 중...' : '이메일 변경'}
                     </button>
@@ -467,7 +467,7 @@ const ProfileCard: React.FC<ProfileCardProps> = ({
                   </p>
                   <button
                     onClick={() => setIsEditingEmail(true)}
-                    className="text-blue-600 hover:text-blue-700 text-sm"
+                    className="text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-500 text-sm"
                   >
                     <svg
                       className="w-4 h-4"
@@ -495,7 +495,7 @@ const ProfileCard: React.FC<ProfileCardProps> = ({
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <svg
-              className="w-5 h-5 text-blue-600"
+              className="w-5 h-5 text-blue-600 dark:text-blue-400"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -627,7 +627,7 @@ const ProfileCard: React.FC<ProfileCardProps> = ({
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <svg
-              className="w-5 h-5 text-orange-600"
+              className="w-5 h-5 text-orange-600 dark:text-orange-400"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -677,7 +677,7 @@ const ProfileCard: React.FC<ProfileCardProps> = ({
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <svg
-              className="w-5 h-5 text-green-600"
+              className="w-5 h-5 text-green-600 dark:text-green-400"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"

--- a/frontend/src/components/profile/ProfileCreateForm.tsx
+++ b/frontend/src/components/profile/ProfileCreateForm.tsx
@@ -134,15 +134,15 @@ const ProfileCreateForm: FC<ProfileCreateFormProps> = ({ onSuccess }) => {
 
           <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2 my-6">
             <div
-              className="bg-blue-600 h-2 rounded-full transition-all duration-500 ease-in-out"
+              className="bg-blue-600 dark:bg-blue-500 h-2 rounded-full transition-all duration-500 ease-in-out"
               style={{ width: `${progressPercentage}%` }}
             ></div>
           </div>
 
           <div className="max-h-[60vh] overflow-y-auto px-2">
             {submitError && (
-              <div className="bg-red-50 border border-red-200 rounded-md p-3 mb-4">
-                <p className="text-red-600 text-sm">{submitError}</p>
+              <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md p-3 mb-4">
+                <p className="text-red-600 dark:text-red-400 text-sm">{submitError}</p>
               </div>
             )}
 
@@ -265,7 +265,7 @@ const ProfileCreateForm: FC<ProfileCreateFormProps> = ({ onSuccess }) => {
             )}
           </div>
 
-          <div className="mt-6 pt-4 border-t">
+          <div className="mt-6 pt-4 border-t border-gray-200 dark:border-gray-700">
             {step === 1 && (
               <div className="flex gap-2 w-full">
                 <Button onClick={() => router.back()} variant="outline" className="w-full">

--- a/frontend/src/components/profile/ProfileView.tsx
+++ b/frontend/src/components/profile/ProfileView.tsx
@@ -96,7 +96,7 @@ const ProfileView: React.FC<ProfileViewProps> = ({ onEdit, onCreate }) => {
               <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-2">
                 프로필을 불러올 수 없습니다
               </h3>
-              <p className="text-red-600 mb-6">{error}</p>
+              <p className="text-red-600 dark:text-red-400 mb-6">{error}</p>
               <div className="space-x-4">
                 <Button onClick={() => window.location.reload()}>
                   다시 시도

--- a/frontend/src/components/review/PendingReviewList.tsx
+++ b/frontend/src/components/review/PendingReviewList.tsx
@@ -33,8 +33,8 @@ export default function PendingReviewList() {
     if (error) {
         return (
             <div className="text-center py-12">
-                <p className="text-red-500 text-lg">에러가 발생했습니다.</p>
-                <p className="text-gray-400 text-sm mt-2">{error.message}</p>
+                <p className="text-red-500 dark:text-red-400 text-lg">에러가 발생했습니다.</p>
+                <p className="text-gray-400 dark:text-gray-500 text-sm mt-2">{error.message}</p>
             </div>
         );
     }
@@ -42,9 +42,9 @@ export default function PendingReviewList() {
     if (!pendingReviews || pendingReviews.length === 0) {
         return (
             <div className="text-center py-12">
-                <MessageSquare className="w-16 h-16 text-gray-300 mx-auto mb-4" />
-                <p className="text-gray-500 text-lg">대기 중인 후기가 없습니다.</p>
-                <p className="text-gray-400 text-sm mt-2">
+                <MessageSquare className="w-16 h-16 text-gray-300 dark:text-gray-600 mx-auto mb-4" />
+                <p className="text-gray-500 dark:text-gray-400 text-lg">대기 중인 후기가 없습니다.</p>
+                <p className="text-gray-400 dark:text-gray-500 text-sm mt-2">
                     매칭이 완료되고 일정 기간이 지나면 후기를 작성할 수 있습니다.
                 </p>
             </div>
@@ -56,29 +56,29 @@ export default function PendingReviewList() {
             {pendingReviews.map((item) => (
                 <div
                     key={item.matchId}
-                    className="bg-gray-50 rounded-lg p-4 border border-gray-200 hover:shadow-md transition-shadow"
+                    className="bg-gray-50 dark:bg-gray-800 rounded-lg p-4 border border-gray-200 dark:border-gray-700 hover:shadow-md transition-shadow"
                 >
                     <div className="flex flex-col gap-3">
                         {/* 이름 */}
                         <div>
-                            <p className="font-bold text-lg text-gray-900 mb-1">
+                            <p className="font-bold text-lg text-gray-900 dark:text-white mb-1">
                                 {item.revieweeName}
                             </p>
-                            <p className="text-sm text-gray-600">
+                            <p className="text-sm text-gray-600 dark:text-gray-400">
                                 {item.revieweeUniversity}
                             </p>
                         </div>
 
                         {/* 종료일 */}
                         {item.matchEndDate && (
-                            <p className="text-xs text-gray-500">
+                            <p className="text-xs text-gray-500 dark:text-gray-400">
                                 종료: {item.matchEndDate}
                             </p>
                         )}
 
                         {/* 후기 작성까지 남은 기간 */}
                         {!item.canCreateReview && item.remainingDays && (
-                            <p className="text-xs text-orange-600 font-medium">
+                            <p className="text-xs text-orange-600 dark:text-orange-400 font-medium">
                                 후기 작성까지 {item.remainingDays}일 남았습니다.
                             </p>
                         )}

--- a/frontend/src/components/review/ReviewForm.tsx
+++ b/frontend/src/components/review/ReviewForm.tsx
@@ -75,14 +75,14 @@ export function ReviewForm({ matchId, targetUserId, onSuccess, review, isEditMod
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
       <div>
-        <label className="block text-sm font-medium text-gray-700 mb-2">
+        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
           평점
         </label>
         <StarRating rating={rating} onRatingChange={setRating} />
       </div>
 
       <div>
-        <label className="block text-sm font-medium text-gray-700">
+        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
           한줄평
         </label>
         <Input
@@ -94,14 +94,16 @@ export function ReviewForm({ matchId, targetUserId, onSuccess, review, isEditMod
       </div>
 
       <div>
-        <label className="block text-sm font-medium text-gray-700">
+        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
           이 사용자와 다시 매칭하고 싶나요?
         </label>
         <div className="flex gap-4 mt-2">
           <button
             type="button"
             className={`px-4 py-2 rounded-lg transition-colors ${
-              recommend ? "bg-blue-600 text-white" : "bg-gray-200 text-gray-700"
+              recommend 
+                ? "bg-blue-600 dark:bg-blue-500 text-white" 
+                : "bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300"
             }`}
             onClick={() => setRecommend(true)}
           >
@@ -110,7 +112,9 @@ export function ReviewForm({ matchId, targetUserId, onSuccess, review, isEditMod
           <button
             type="button"
             className={`px-4 py-2 rounded-lg transition-colors ${
-              !recommend ? "bg-red-500 text-white" : "bg-gray-200 text-gray-700"
+              !recommend 
+                ? "bg-red-500 dark:bg-red-600 text-white" 
+                : "bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300"
             }`}
             onClick={() => setRecommend(false)}
           >
@@ -120,7 +124,7 @@ export function ReviewForm({ matchId, targetUserId, onSuccess, review, isEditMod
       </div>
 
       {error && (
-        <div className="text-red-500 text-sm">{error.message}</div>
+        <div className="text-red-500 dark:text-red-400 text-sm">{error.message}</div>
       )}
 
       <Button type="submit" disabled={loading} className="w-full">

--- a/frontend/src/components/review/ReviewFormModal.tsx
+++ b/frontend/src/components/review/ReviewFormModal.tsx
@@ -60,8 +60,8 @@ export function ReviewFormModal({
                             leaveFrom="opacity-100 scale-100 translate-y-0"
                             leaveTo="opacity-0 scale-95 translate-y-4"
                         >
-                            <Dialog.Panel className="w-full max-w-lg rounded-lg bg-white p-6 shadow-xl">
-                                <Dialog.Title className="text-xl font-semibold mb-4">
+                            <Dialog.Panel className="w-full max-w-lg rounded-lg bg-white dark:bg-gray-800 p-6 shadow-xl">
+                                <Dialog.Title className="text-xl font-semibold mb-4 text-gray-900 dark:text-white">
                                     {isEditMode ? `${revieweeName} 리뷰 수정` : `${revieweeName} 리뷰 작성`}
                                 </Dialog.Title>
 

--- a/frontend/src/components/review/WrittenReviewList.tsx
+++ b/frontend/src/components/review/WrittenReviewList.tsx
@@ -260,8 +260,8 @@ export default function WrittenReviewList() {
     if (error) {
         return (
             <div className="text-center py-12">
-                <p className="text-red-500 text-lg">에러가 발생했습니다.</p>
-                <p className="text-gray-400 text-sm mt-2">{error}</p>
+                <p className="text-red-500 dark:text-red-400 text-lg">에러가 발생했습니다.</p>
+                <p className="text-gray-400 dark:text-gray-500 text-sm mt-2">{error}</p>
             </div>
         );
     }
@@ -269,9 +269,9 @@ export default function WrittenReviewList() {
     if (matchesWithReviews.length === 0) {
         return (
             <div className="text-center py-12">
-                <MessageSquare className="w-16 h-16 text-gray-300 mx-auto mb-4" />
-                <p className="text-gray-500 text-lg">작성된 리뷰가 없습니다.</p>
-                <p className="text-gray-400 text-sm mt-2">
+                <MessageSquare className="w-16 h-16 text-gray-300 dark:text-gray-600 mx-auto mb-4" />
+                <p className="text-gray-500 dark:text-gray-400 text-lg">작성된 리뷰가 없습니다.</p>
+                <p className="text-gray-400 dark:text-gray-500 text-sm mt-2">
                     작성한 리뷰가 여기에 표시됩니다.
                 </p>
             </div>
@@ -283,16 +283,16 @@ export default function WrittenReviewList() {
             {matchesWithReviews.map((matchData) => (
                 <div
                     key={matchData.matchId}
-                    className="bg-gray-50 rounded-lg p-4 border border-gray-200"
+                    className="bg-gray-50 dark:bg-gray-800 rounded-lg p-4 border border-gray-200 dark:border-gray-700"
                 >
                     <div className="flex items-center gap-3 mb-3">
-                        <User className="w-5 h-5 text-gray-500" />
+                        <User className="w-5 h-5 text-gray-500 dark:text-gray-400" />
                         <div className="flex-1">
-                            <p className="font-bold text-lg text-gray-900">
+                            <p className="font-bold text-lg text-gray-900 dark:text-white">
                                 {matchData.partnerName}
                             </p>
                             {matchData.partnerUniversity && (
-                                <p className="text-sm text-gray-600">
+                                <p className="text-sm text-gray-600 dark:text-gray-400">
                                     {matchData.partnerUniversity}
                                 </p>
                             )}
@@ -301,8 +301,8 @@ export default function WrittenReviewList() {
 
                     {/* 리뷰가 없는 경우 안내 */}
                     {!matchData.myReview && !matchData.partnerReview && (
-                        <div className="bg-blue-50 rounded-lg p-3 border border-blue-200 mb-3">
-                            <p className="text-sm text-blue-700">
+                        <div className="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-3 border border-blue-200 dark:border-blue-800 mb-3">
+                            <p className="text-sm text-blue-700 dark:text-blue-300">
                                 아직 작성된 리뷰가 없습니다.
                             </p>
                         </div>
@@ -311,9 +311,9 @@ export default function WrittenReviewList() {
                     <div className="space-y-3">
                         {/* 내가 작성한 리뷰 */}
                         {matchData.myReview && (
-                            <div className="bg-white rounded-lg p-3 border border-blue-200">
+                            <div className="bg-white dark:bg-gray-700 rounded-lg p-3 border border-blue-200 dark:border-blue-800">
                                 <div className="flex items-center justify-between mb-2">
-                                    <p className="text-sm font-semibold text-blue-700">내가 작성한 리뷰</p>
+                                    <p className="text-sm font-semibold text-blue-700 dark:text-blue-300">내가 작성한 리뷰</p>
                                     <div className="flex items-center gap-2">
                                         <div className="flex items-center gap-1">
                                             {Array.from({ length: 5 }).map((_, i) => (
@@ -323,8 +323,8 @@ export default function WrittenReviewList() {
                                                     fill={i < matchData.myReview!.rating ? "currentColor" : "none"}
                                                     className={
                                                         i < matchData.myReview!.rating
-                                                            ? "text-yellow-400"
-                                                            : "text-gray-300"
+                                                            ? "text-yellow-400 dark:text-yellow-500"
+                                                            : "text-gray-300 dark:text-gray-600"
                                                     }
                                                 />
                                             ))}
@@ -332,7 +332,7 @@ export default function WrittenReviewList() {
                                         {/* 수정 버튼 */}
                                         <button
                                             onClick={() => handleEditReview(matchData.myReview!)}
-                                            className="p-1 text-gray-400 hover:text-blue-600 transition-colors"
+                                            className="p-1 text-gray-400 dark:text-gray-500 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
                                             title="리뷰 수정"
                                         >
                                             <Edit2 className="w-4 h-4" />
@@ -340,7 +340,7 @@ export default function WrittenReviewList() {
                                         <button
                                             onClick={() => handleDeleteReview(matchData.myReview!.reviewId)}
                                             disabled={deletingReviewId === matchData.myReview!.reviewId || deleting}
-                                            className="p-1 text-gray-400 hover:text-red-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                                            className="p-1 text-gray-400 dark:text-gray-500 hover:text-red-600 dark:hover:text-red-400 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                                             title="리뷰 삭제"
                                         >
                                             {deletingReviewId === matchData.myReview!.reviewId ? (
@@ -352,17 +352,17 @@ export default function WrittenReviewList() {
                                     </div>
                                 </div>
                                 {matchData.myReview.content && (
-                                    <p className="text-sm text-gray-700 mt-2">
+                                    <p className="text-sm text-gray-700 dark:text-gray-300 mt-2">
                                         {matchData.myReview.content}
                                     </p>
                                 )}
                                 <div className="flex items-center gap-2 mt-2">
                                     {matchData.myReview.recommend ? (
-                                        <ThumbsUp className="w-4 h-4 text-green-600" />
+                                        <ThumbsUp className="w-4 h-4 text-green-600 dark:text-green-400" />
                                     ) : (
-                                        <ThumbsDown className="w-4 h-4 text-red-600" />
+                                        <ThumbsDown className="w-4 h-4 text-red-600 dark:text-red-400" />
                                     )}
-                                    <span className="text-xs text-gray-500">
+                                    <span className="text-xs text-gray-500 dark:text-gray-400">
                                         {matchData.myReview.recommend ? "추천" : "비추천"}
                                     </span>
                                 </div>
@@ -371,9 +371,9 @@ export default function WrittenReviewList() {
 
                         {/* 상대방이 작성한 리뷰 */}
                         {matchData.partnerReview && (
-                            <div className="bg-white rounded-lg p-3 border border-gray-200">
+                            <div className="bg-white dark:bg-gray-700 rounded-lg p-3 border border-gray-200 dark:border-gray-600">
                                 <div className="flex items-center justify-between mb-2">
-                                    <p className="text-sm font-semibold text-gray-700">
+                                    <p className="text-sm font-semibold text-gray-700 dark:text-gray-300">
                                         {matchData.partnerName}님이 작성한 리뷰
                                     </p>
                                     <div className="flex items-center gap-1">
@@ -384,25 +384,25 @@ export default function WrittenReviewList() {
                                                 fill={i < matchData.partnerReview!.rating ? "currentColor" : "none"}
                                                 className={
                                                     i < matchData.partnerReview!.rating
-                                                        ? "text-yellow-400"
-                                                        : "text-gray-300"
+                                                        ? "text-yellow-400 dark:text-yellow-500"
+                                                        : "text-gray-300 dark:text-gray-600"
                                                 }
                                             />
                                         ))}
                                     </div>
                                 </div>
                                 {matchData.partnerReview.content && (
-                                    <p className="text-sm text-gray-700 mt-2">
+                                    <p className="text-sm text-gray-700 dark:text-gray-300 mt-2">
                                         {matchData.partnerReview.content}
                                     </p>
                                 )}
                                 <div className="flex items-center gap-2 mt-2">
                                     {matchData.partnerReview.recommend ? (
-                                        <ThumbsUp className="w-4 h-4 text-green-600" />
+                                        <ThumbsUp className="w-4 h-4 text-green-600 dark:text-green-400" />
                                     ) : (
-                                        <ThumbsDown className="w-4 h-4 text-red-600" />
+                                        <ThumbsDown className="w-4 h-4 text-red-600 dark:text-red-400" />
                                     )}
-                                    <span className="text-xs text-gray-500">
+                                    <span className="text-xs text-gray-500 dark:text-gray-400">
                                         {matchData.partnerReview.recommend ? "추천" : "비추천"}
                                     </span>
                                 </div>
@@ -412,7 +412,7 @@ export default function WrittenReviewList() {
 
                     {/* 재매칭 버튼 */}
                     {matchData.canRematch && (
-                        <div className="mt-4 pt-3 border-t border-gray-200">
+                        <div className="mt-4 pt-3 border-t border-gray-200 dark:border-gray-700">
                             <Button
                                 variant="primary"
                                 size="md"
@@ -437,9 +437,9 @@ export default function WrittenReviewList() {
 
                     {/* PENDING 상태의 재매칭이 있는 경우 안내 메시지 */}
                     {matchData.hasPendingRematch && !matchData.canRematch && (
-                        <div className="mt-4 pt-3 border-t border-gray-200">
-                            <div className="bg-blue-50 rounded-lg p-3 border border-blue-200">
-                                <p className="text-sm text-blue-700 font-medium">
+                        <div className="mt-4 pt-3 border-t border-gray-200 dark:border-gray-700">
+                            <div className="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-3 border border-blue-200 dark:border-blue-800">
+                                <p className="text-sm text-blue-700 dark:text-blue-300 font-medium">
                                     재매칭 요청이 진행 중입니다. 채팅방에서 확인해주세요.
                                 </p>
                             </div>

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -9,15 +9,15 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant = 'primary', size = 'md', loading = false, disabled, children, ...props }, ref) => {
+  ({ className, variant = 'primary', size = 'md', loading = false, disabled, children, type = 'button', ...props }, ref) => {
     const baseStyles = 'inline-flex items-center justify-center rounded-lg font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 btn-hover';
     
     const variants = {
-      primary: 'bg-gradient-to-r from-blue-600 to-blue-700 text-white shadow-md hover:from-blue-700 hover:to-blue-800 focus:ring-blue-500',
-      secondary: 'bg-gradient-to-r from-gray-600 to-gray-700 text-white shadow-md hover:from-gray-700 hover:to-gray-800 focus:ring-gray-500',
-      danger: 'bg-gradient-to-r from-red-600 to-red-700 text-white shadow-md hover:from-red-700 hover:to-red-800 focus:ring-red-500',
-      ghost: 'text-gray-700 hover:bg-gray-100 hover:text-gray-900 focus:ring-gray-500',
-      outline: 'border-2 border-gray-300 bg-white text-gray-700 hover:bg-gray-50 hover:border-gray-400 focus:ring-gray-500',
+      primary: 'bg-gradient-to-r from-blue-600 to-blue-700 text-white shadow-md hover:from-blue-700 hover:to-blue-800 focus:ring-blue-500 dark:from-blue-500 dark:to-blue-600',
+      secondary: 'bg-gradient-to-r from-gray-600 to-gray-700 text-white shadow-md hover:from-gray-700 hover:to-gray-800 focus:ring-gray-500 dark:from-gray-500 dark:to-gray-600',
+      danger: 'bg-gradient-to-r from-red-600 to-red-700 text-white shadow-md hover:from-red-700 hover:to-red-800 focus:ring-red-500 dark:from-red-500 dark:to-red-600',
+      ghost: 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-900 dark:hover:text-gray-100 focus:ring-gray-500',
+      outline: 'border-2 border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 hover:border-gray-400 dark:hover:border-gray-500 focus:ring-gray-500',
     };
     
     const sizes = {
@@ -28,6 +28,8 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 
     return (
       <button
+        type={type} 
+        {...props}  
         className={cn(
           baseStyles,
           variants[variant],
@@ -36,7 +38,6 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         )}
         disabled={disabled || loading}
         ref={ref}
-        {...props}
       >
         {loading && (
           <svg

--- a/frontend/src/lib/utils/helpers.ts
+++ b/frontend/src/lib/utils/helpers.ts
@@ -124,6 +124,7 @@ export const getErrorMessage = (error: unknown): string => {
   }
   
   if (error && typeof error === 'object') {
+    // ApiError 타입인 경우 (인터셉터에서 변환된 에러)
     if ('message' in error) {
       return String(error.message);
     }
@@ -132,12 +133,11 @@ export const getErrorMessage = (error: unknown): string => {
     if ('response' in error) {
       const axiosError = error as any;
       const responseData = axiosError.response?.data;
+      // 백엔드 ErrorResponse 구조: { timestamp, status, error, message }
       if (responseData?.message) {
         return responseData.message;
       }
-      if (responseData?.error) {
-        return responseData.error;
-      }
+      // 'error' 필드는 errorCode이므로 메시지로 사용하지 않음
       return `서버 오류 (${axiosError.response?.status || '알 수 없음'})`;
     }
     

--- a/frontend/src/types/match.ts
+++ b/frontend/src/types/match.ts
@@ -74,8 +74,11 @@ export interface MatchStatusItem {
   preferenceScore: number;
   createdAt: string;
   confirmedAt?: string;
-  message: string;
+  message?: string;
   partner: MatchStatusPartnerInfo;
+  myResponse: 'PENDING' | 'ACCEPTED' | 'REJECTED';
+  partnerResponse: 'PENDING' | 'ACCEPTED' | 'REJECTED';
+  waitingForPartner: boolean;
 }
 
 export interface MatchStatusResponse {


### PR DESCRIPTION
<!--
  PR 네이밍 규칙:
  [FE/feat] PR 내용
-->

## 관련 이슈

- close #90 

## PR / 과제 설명 
- 전체 페이지/컴포넌트 다크모드 지원 추가 
- UI 디자인 통일 및 레이아웃 개선 (PageContainer 컴포넌트 추가)
- 백엔드 에러 처리 매핑 개선 (ErrorResponse 구조 반영)
- 타입 안정성 개선 (Button, SElect, chat page)
- 메인 페이지 및 매칭 상태 페이지 UI 개선

→ 프론트엔드 작업 마무리 했습니다.